### PR TITLE
add solve from scipy instead of inv

### DIFF
--- a/mgwr/diagnostics.py
+++ b/mgwr/diagnostics.py
@@ -4,6 +4,7 @@ Diagnostics for estimated gwr models
 __author__ = "Taylor Oshan tayoshan@gmail.com"
 
 import numpy as np
+from scipy import linalg
 from spglm.family import Gaussian, Poisson, Binomial
 
 def get_AICc(gwr):
@@ -83,7 +84,6 @@ def get_CV(gwr):
     return cv
 
 def corr(cov):
-    sd = np.diag(np.sqrt(np.diag(cov)))
-    invsd = np.linalg.inv(sd)
+    invsd = np.diag(1/np.sqrt(np.diag(cov)))
     cors = np.dot(np.dot(invsd, cov), invsd)
     return cors

--- a/mgwr/search.py
+++ b/mgwr/search.py
@@ -3,6 +3,7 @@
 __author__ = "Taylor Oshan"
 
 import numpy as np
+from scipy import linalg
 from copy import deepcopy
 import copy
 from collections import namedtuple
@@ -173,7 +174,7 @@ def multi_bw(init, y, X, n, k, family, tol, max_iter, rss_score,
         for i in range(n):
             wi = optim_model.W[i].reshape(-1,1)
             xT = (X * wi).T
-            P = np.dot(np.linalg.inv(np.dot(xT, X)), xT)
+            P = linalg.solve(xT.dot(X), xT)
             R[i,:,j] = X[i,j]*P[j]
 
     XB = np.multiply(param, X)


### PR DESCRIPTION
this uses solve instead of inv on the `(p,p)` parameter covariance matrices in `solve` and uses `1/sd` instead of `inv(sd)`, which works because `sd` is diagonal. 