### PR TITLE
(docs) reflect api (kernels) change in the docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -37,12 +37,9 @@ Kernel Specification
 .. autosummary::
    :toctree: generated/
 
-    mgwr.kernels.fix_gauss
-    mgwr.kernels.adapt_gauss
-    mgwr.kernels.fix_bisquare
-    mgwr.kernels.adapt_bisquare
-    mgwr.kernels.fix_exp
-    mgwr.kernels.adapt_exp
+    mgwr.kernels.Kernel
+    mgwr.kernels.local_cdist
+
 
 Bandwidth Selection
 ~~~~~~~~~~~~~~~~~~~~

--- a/doc/generated/mgwr.gwr.GWResults.influ.rst
+++ b/doc/generated/mgwr.gwr.GWResults.influ.rst
@@ -1,9 +1,0 @@
-mgwr.gwr.GWRResults
-===================
-
-.. currentmodule:: mgwr.gwr
-
-.. automethod:: GWRResults.influ
-
-
-   

--- a/doc/generated/mgwr.gwr.GWResults.tr_STS.rst
+++ b/doc/generated/mgwr.gwr.GWResults.tr_STS.rst
@@ -1,9 +1,0 @@
-mgwr.gwr.GWRResults
-===================
-
-.. currentmodule:: mgwr.gwr
-
-.. automethod:: GWRResults.tr_STS
-
-
-   

--- a/doc/generated/mgwr.kernels.Kernel.rst
+++ b/doc/generated/mgwr.kernels.Kernel.rst
@@ -1,0 +1,22 @@
+mgwr.kernels.Kernel
+===================
+
+.. currentmodule:: mgwr.kernels
+
+.. autoclass:: Kernel
+
+   
+   .. automethod:: __init__
+
+   
+   .. rubric:: Methods
+
+   .. autosummary::
+   
+      ~Kernel.__init__
+   
+   
+
+   
+   
+   

--- a/doc/generated/mgwr.kernels.adapt_bisquare.rst
+++ b/doc/generated/mgwr.kernels.adapt_bisquare.rst
@@ -1,6 +1,0 @@
-mgwr.kernels.adapt\_bisquare
-============================
-
-.. currentmodule:: mgwr.kernels
-
-.. autofunction:: adapt_bisquare

--- a/doc/generated/mgwr.kernels.adapt_exp.rst
+++ b/doc/generated/mgwr.kernels.adapt_exp.rst
@@ -1,6 +1,0 @@
-mgwr.kernels.adapt\_exp
-=======================
-
-.. currentmodule:: mgwr.kernels
-
-.. autofunction:: adapt_exp

--- a/doc/generated/mgwr.kernels.adapt_gauss.rst
+++ b/doc/generated/mgwr.kernels.adapt_gauss.rst
@@ -1,6 +1,0 @@
-mgwr.kernels.adapt\_gauss
-=========================
-
-.. currentmodule:: mgwr.kernels
-
-.. autofunction:: adapt_gauss

--- a/doc/generated/mgwr.kernels.fix_bisquare.rst
+++ b/doc/generated/mgwr.kernels.fix_bisquare.rst
@@ -1,6 +1,0 @@
-mgwr.kernels.fix\_bisquare
-==========================
-
-.. currentmodule:: mgwr.kernels
-
-.. autofunction:: fix_bisquare

--- a/doc/generated/mgwr.kernels.fix_exp.rst
+++ b/doc/generated/mgwr.kernels.fix_exp.rst
@@ -1,6 +1,0 @@
-mgwr.kernels.fix\_exp
-=====================
-
-.. currentmodule:: mgwr.kernels
-
-.. autofunction:: fix_exp

--- a/doc/generated/mgwr.kernels.fix_gauss.rst
+++ b/doc/generated/mgwr.kernels.fix_gauss.rst
@@ -1,6 +1,0 @@
-mgwr.kernels.fix\_gauss
-=======================
-
-.. currentmodule:: mgwr.kernels
-
-.. autofunction:: fix_gauss

--- a/doc/generated/mgwr.kernels.local_cdist.rst
+++ b/doc/generated/mgwr.kernels.local_cdist.rst
@@ -1,0 +1,6 @@
+mgwr.kernels.local\_cdist
+=========================
+
+.. currentmodule:: mgwr
+
+.. autoattribute:: kernels.local_cdist


### PR DESCRIPTION
[`kernels` API has undergone drastic changes](https://github.com/pysal/mgwr/commit/7459714b5c794bb1dff9f9d15ec938de0629001f#diff-1f3d7dec52d318c5f783e7ca914f6855R24), but these changes are not reflected in the docs. 
This PR is to accommodate the changes in the docs website.