### PR TITLE
check_constant change

### DIFF
--- a/mgwr/sel_bw.py
+++ b/mgwr/sel_bw.py
@@ -357,7 +357,7 @@ class Sel_BW(object):
     def _mbw(self):
         y = self.y
         if self.constant:
-            X = USER.check_constant(self.X_loc)
+            X,keep_x,warn = USER.check_constant(self.X_loc)
         else:
             X = self.X_loc
         n, k = X.shape


### PR DESCRIPTION
The returned value of the github version of `spreg`'s [`check_constant`](https://github.com/pysal/spreg/blob/master/spreg/user_output.py#L582) function is [a tuple whose first element is the matrix with independent variables plus constant]( https://github.com/pysal/spreg/blob/master/spreg/user_output.py#L638)