### PR TITLE
fix typo in uniform kernel branch

### DIFF
--- a/mgwr/kernels.py
+++ b/mgwr/kernels.py
@@ -67,7 +67,7 @@ class Kernel(object):
         if self.function == 'triangular':
             return 1 - zs
         elif self.function == 'uniform':
-            return np.ones(zi.shape) * 0.5
+            return np.ones(zs.shape) * 0.5
         elif self.function == 'quadratic':
             return (3. / 4) * (1 - zs**2)
         elif self.function == 'quartic':


### PR DESCRIPTION
Change `zi` to `zs` in the uniform kernel option, there's no variable named `zi` in scope.