### PR TITLE
Update spglm install in unittest

### DIFF
--- a/.ci/37.yaml
+++ b/.ci/37.yaml
@@ -8,9 +8,6 @@ dependencies:
   - pandas>=1
   - scikit-learn>=0.22
   - scipy>=1.0
-  - spglm
-  - spreg
-  # testing
   - codecov
   - coverage
   - pytest

--- a/.ci/37.yaml
+++ b/.ci/37.yaml
@@ -8,6 +8,7 @@ dependencies:
   - pandas>=1
   - scikit-learn>=0.22
   - scipy>=1.0
+  - spreg
   - codecov
   - coverage
   - pytest

--- a/.ci/38.yaml
+++ b/.ci/38.yaml
@@ -8,9 +8,6 @@ dependencies:
   - pandas>=1
   - scikit-learn>=0.22
   - scipy>=1.0
-  - spglm
-  - spreg
-  # testing
   - codecov
   - coverage
   - pytest

--- a/.ci/38.yaml
+++ b/.ci/38.yaml
@@ -8,6 +8,7 @@ dependencies:
   - pandas>=1
   - scikit-learn>=0.22
   - scipy>=1.0
+  - spreg
   - codecov
   - coverage
   - pytest

--- a/.ci/39-DEV.yaml
+++ b/.ci/39-DEV.yaml
@@ -9,9 +9,7 @@ dependencies:
   - pandas>=1
   - scikit-learn>=0.22
   - scipy>=1.0
-  - spglm
   - spreg
-  # testing
   - codecov
   - coverage
   - pytest

--- a/.ci/39.yaml
+++ b/.ci/39.yaml
@@ -8,9 +8,7 @@ dependencies:
   - pandas>=1
   - scikit-learn>=0.22
   - scipy>=1.0
-  - spglm
   - spreg
-  # testing
   - codecov
   - coverage
   - pytest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,8 +32,7 @@
            micromamba-version: 'latest'
        - name: install spglm via pip
          shell: bash -l {0}
-         run: pip install git+https://github.com/pysal/spglm.git@master
-         upgrade: true
+         run: pip install --upgrade git+https://github.com/pysal/spglm.git@master
          
        - name: install spreg via pip
          shell: bash -l {0}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@
            micromamba-version: 'latest'
        - name: install spglm via pip
          shell: bash -l {0}
-         run: pip install spglm 
+         run: pip install git+https://github.com/pysal/spglm.git 
          
        - name: install spreg via pip
          shell: bash -l {0}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@
            micromamba-version: 'latest'
        - name: install spglm via pip
          shell: bash -l {0}
-         run: pip install --upgrade git+https://github.com/pysal/spglm.git 
+         run: pip install git+https://github.com/pysal/spglm.git@master
          
        - name: install spreg via pip
          shell: bash -l {0}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -32,7 +32,7 @@
            micromamba-version: 'latest'
        - name: install spglm via pip
          shell: bash -l {0}
-         run: pip install git+https://github.com/pysal/spglm.git 
+         run: pip install --upgrade git+https://github.com/pysal/spglm.git 
          
        - name: install spreg via pip
          shell: bash -l {0}

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -33,6 +33,7 @@
        - name: install spglm via pip
          shell: bash -l {0}
          run: pip install git+https://github.com/pysal/spglm.git@master
+         upgrade: true
          
        - name: install spreg via pip
          shell: bash -l {0}


### PR DESCRIPTION
In unittest environment setup, install `spglm` from GitHub master branch to reflect the [recent change](https://github.com/pysal/spglm/pull/32) in `spglm` due to numpy deprecation of `np.float`.