### PR TITLE
Parallelization: switch from multiprocessing to joblib

### DIFF
--- a/mgwr/gwr.py
+++ b/mgwr/gwr.py
@@ -3,6 +3,7 @@
 __author__ = "Taylor Oshan Tayoshan@gmail.com"
 
 import copy
+import os
 from typing import Optional
 import numpy as np
 import numpy.linalg as la
@@ -13,10 +14,10 @@ from spglm.family import Gaussian, Binomial, Poisson
 from spglm.glm import GLM, GLMResults
 from spglm.iwls import iwls, _compute_betas_gwr
 from spglm.utils import cache_readonly
+from joblib import Parallel, delayed
 from .diagnostics import get_AIC, get_AICc, get_BIC, corr
 from .kernels import *
 from .summary import *
-import multiprocessing as mp
 
 
 class GWR(GLM):
@@ -85,6 +86,10 @@ class GWR(GLM):
 
     name_x        : list of strings
                     Names of independent variables for use in output
+
+    n_jobs        : integer
+                    The number of jobs (default 1) to run in parallel. -1 means using all processors.
+                            
 
     Attributes
     ----------
@@ -210,7 +215,7 @@ class GWR(GLM):
 
     def __init__(self, coords, y, X, bw, family=Gaussian(), offset=None,
                  sigma2_v1=True, kernel='bisquare', fixed=False, constant=True,
-                 spherical=False, hat_matrix=False, name_x=None):
+                 spherical=False, hat_matrix=False, name_x=None,n_jobs=1):
         """
         Initialize class
         """
@@ -234,6 +239,7 @@ class GWR(GLM):
         self.spherical = spherical
         self.hat_matrix = hat_matrix
         self.name_x = name_x
+        self.n_jobs = n_jobs
 
     def _build_wi(self, i, bw):
 
@@ -285,7 +291,7 @@ class GWR(GLM):
             return influ, resid, predy, betas.reshape(-1), w, Si, tr_STS_i, CCT
 
     def fit(self, ini_params=None, tol=1.0e-5, max_iter=20, solve='iwls',
-            lite=False, pool=None):
+            lite=False):
         """
         Method that fits a model with a particular estimation routine.
 
@@ -312,7 +318,6 @@ class GWR(GLM):
                         bandwidth selection (could speed up
                         bandwidth selection for GWR) or to estimate
                         a full GWR. Default is False.
-        pool          : A multiprocessing Pool object to enable parallel fitting; default is None.
 
         Returns
         -------
@@ -335,11 +340,7 @@ class GWR(GLM):
             else:
                 m = self.points.shape[0]
 
-            if pool:
-                rslt = pool.map(self._local_fit,
-                                range(m))  #parallel using mp.Pool
-            else:
-                rslt = map(self._local_fit, range(m))  #sequential
+            rslt = Parallel(n_jobs=self.n_jobs)(delayed(self._local_fit)(i) for i in range(m))
 
             rslt_list = list(zip(*rslt))
             influ = np.array(rslt_list[0]).reshape(-1, 1)
@@ -1492,6 +1493,9 @@ class MGWR(GWR):
     name_x        : list of strings
                     Names of independent variables for use in output
 
+    n_jobs        : integer
+                    The number of jobs (default 1) to run in parallel. -1 means using all processors.
+
     Examples
     --------
 
@@ -1521,7 +1525,7 @@ class MGWR(GWR):
 
     def __init__(self, coords, y, X, selector, sigma2_v1=True,
                  kernel='bisquare', fixed=False, constant=True,
-                 spherical=False, hat_matrix=False, name_x=None):
+                 spherical=False, hat_matrix=False, name_x=None,n_jobs=1):
         """
         Initialize class
         """
@@ -1544,6 +1548,7 @@ class MGWR(GWR):
         self.exog_scale = None
         self_fit_params = None
         self.name_x = name_x
+        self.n_jobs = n_jobs
 
     def _chunk_compute_R(self, chunk_id=0):
         """
@@ -1599,7 +1604,7 @@ class MGWR(GWR):
             return ENP_j, CCT, pR
         return ENP_j, CCT
 
-    def fit(self, n_chunks=1, pool=None):
+    def fit(self, n_chunks=1):
         """
         Compute MGWR inference by chunk to reduce memory footprint.
         See Li and Fotheringham, 2020, IJGIS.
@@ -1610,7 +1615,6 @@ class MGWR(GWR):
         n_chunks      : integer, optional
                         A number of chunks parameter to reduce memory usage.
                         e.g. n_chunks=2 should reduce overall memory usage by 2.
-        pool          : A multiprocessing Pool object to enable parallel fitting; default is None.
 
         Returns
         -------
@@ -1627,15 +1631,16 @@ class MGWR(GWR):
                      desc=''):  #otherwise, just passthrough the range
                 return x
 
-        if pool:
-            self.n_chunks = pool._processes * n_chunks
-            rslt = tqdm(
-                pool.imap(self._chunk_compute_R, range(self.n_chunks)),
-                total=self.n_chunks, desc='Inference')
+        if self.n_jobs = -1:
+            max_processors = os.cpu_count()
+            self.n_chunks = max_processors * n_chunks
         else:
-            self.n_chunks = n_chunks
-            rslt = map(self._chunk_compute_R,
-                       tqdm(range(self.n_chunks), desc='Inference'))
+            self.n_chunks = self.n_jobs * n_chunks
+
+        # Using joblib for parallel processing with a tqdm progress bar
+        rslt = tqdm(Parallel(n_jobs=self.n_jobs)(
+                    delayed(self._chunk_compute_R)(i) for i in range(self.n_chunks)),
+                total=self.n_chunks, desc='Inference')
 
         rslt_list = list(zip(*rslt))
         ENP_j = np.sum(np.array(rslt_list[0]), axis=0)

--- a/mgwr/gwr.py
+++ b/mgwr/gwr.py
@@ -1631,7 +1631,7 @@ class MGWR(GWR):
                      desc=''):  #otherwise, just passthrough the range
                 return x
 
-        if self.n_jobs = -1:
+        if self.n_jobs == -1:
             max_processors = os.cpu_count()
             self.n_chunks = max_processors * n_chunks
         else:

--- a/mgwr/gwr.py
+++ b/mgwr/gwr.py
@@ -1671,7 +1671,7 @@ class MGWR(GWR):
         Q = []
         I = np.eye(self.n)
         for j1 in range(self.k):
-            Aj = GWR(self.coords,self.y,self.X[:,j1].reshape(-1,1),bw=self.bws[j1],hat_matrix=True,constant=False).fit().S
+            Aj = GWR(self.coords,self.y,self.X[:,j1].reshape(-1,1),bw=self.bws[j1],hat_matrix=True,constant=False,n_jobs=self.n_jobs).fit().S
             Pj = []
             for j2 in range(self.k):
                 if j1 == j2:

--- a/mgwr/sel_bw.py
+++ b/mgwr/sel_bw.py
@@ -385,7 +385,7 @@ class Sel_BW(object):
         def bw_func(y, X):
             selector = Sel_BW(coords, y, X, X_glob=[], family=family,
                               kernel=kernel, fixed=fixed, offset=offset,
-                              constant=False, spherical=self.spherical)
+                              constant=False, spherical=self.spherical,n_jobs=self.n_jobs)
             return selector
 
         def sel_func(bw_func, bw_min=None, bw_max=None):

--- a/mgwr/sel_bw.py
+++ b/mgwr/sel_bw.py
@@ -176,7 +176,7 @@ class Sel_BW(object):
 
     def __init__(self, coords, y, X_loc, X_glob=None, family=Gaussian(),
                  offset=None, kernel='bisquare', fixed=False, multi=False,
-                 constant=True, spherical=False):
+                 constant=True, spherical=False,n_jobs=1):
         self.coords = np.array(coords)
         self.y = y
         self.X_loc = X_loc
@@ -195,6 +195,7 @@ class Sel_BW(object):
         self._functions = []
         self.constant = constant
         self.spherical = spherical
+        self.n_jobs = n_jobs
         self.search_params = {}
 
     def search(self, search_method='golden_section', criterion='AICc',

--- a/mgwr/tests/test_parallel.py
+++ b/mgwr/tests/test_parallel.py
@@ -6,7 +6,6 @@ import os
 import libpysal as ps
 from libpysal import io
 import numpy as np
-import multiprocessing as mp
 import unittest
 import pandas
 from types import SimpleNamespace
@@ -16,7 +15,7 @@ from ..diagnostics import get_AICc, get_AIC, get_BIC, get_CV
 from spglm.family import Gaussian, Poisson, Binomial
 
 
-class TestGWRGaussianPool(unittest.TestCase):
+class TestGWRGaussianParallel(unittest.TestCase):
     def setUp(self):
         data_path = ps.examples.get_path("GData_utm.csv")
         data = io.open(data_path)
@@ -37,9 +36,8 @@ class TestGWRGaussianPool(unittest.TestCase):
         MGWR_path = os.path.join(
             os.path.dirname(__file__), 'georgia_mgwr_results.csv')
         self.MGWR = pandas.read_csv(MGWR_path)
-        self.pool = mp.Pool(4)
 
-    def test_BS_NN_Pool(self):
+    def test_BS_NN_Parallel(self):
         est_Int = self.BS_NN.by_col(' est_Intercept')
         se_Int = self.BS_NN.by_col(' se_Intercept')
         t_Int = self.BS_NN.by_col(' t_Intercept')
@@ -69,9 +67,9 @@ class TestGWRGaussianPool(unittest.TestCase):
         spat_var_p_vals = [0., 0.0, 0.5, 0.2]
 
         model = GWR(self.coords, self.y, self.X, bw=90.000, fixed=False,
-                    sigma2_v1=False)
+                    sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         adj_alpha = rslt.adj_alpha
         alpha = 0.01017489
@@ -117,14 +115,14 @@ class TestGWRGaussianPool(unittest.TestCase):
         np.testing.assert_allclose(cooksD, rslt.cooksD, rtol=1e-00)
 
         sel = Sel_BW(self.coords, self.y, self.X)
-        bw = sel.search(pool=self.pool)
-        model = GWR(self.coords, self.y, self.X, bw)
-        result = model.fit(pool=self.pool)
+        bw = sel.search()
+        model = GWR(self.coords, self.y, self.X, bw,n_jobs=-1)
+        result = model.fit()
 
         p_vals = result.spatial_variability(sel, 10)
         np.testing.assert_allclose(spat_var_p_vals, p_vals, rtol=1e-04)
 
-    def test_GS_F_Pool(self):
+    def test_GS_F_Parallel(self):
         est_Int = self.GS_F.by_col(' est_Intercept')
         se_Int = self.GS_F.by_col(' se_Intercept')
         t_Int = self.GS_F.by_col(' t_Intercept')
@@ -145,9 +143,9 @@ class TestGWRGaussianPool(unittest.TestCase):
         cooksD = np.array(self.GS_F.by_col(' CooksD')).reshape((-1, 1))
 
         model = GWR(self.coords, self.y, self.X, bw=87308.298,
-                    kernel='gaussian', fixed=True, sigma2_v1=False)
+                    kernel='gaussian', fixed=True, sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -177,26 +175,25 @@ class TestGWRGaussianPool(unittest.TestCase):
         np.testing.assert_allclose(inf, rslt.influ, rtol=1e-04)
         np.testing.assert_allclose(cooksD, rslt.cooksD, rtol=1e-00)
 
-    def test_MGWR_Pool(self):
+    def test_MGWR_Parallel(self):
         std_y = (self.y - self.y.mean()) / self.y.std()
         std_X = (self.mgwr_X - self.mgwr_X.mean(axis=0)) / \
             self.mgwr_X.std(axis=0)
 
-        selector = Sel_BW(self.coords, std_y, std_X, multi=True, constant=True)
-        selector.search(multi_bw_min=[2], multi_bw_max=[159], pool=self.pool)
+        selector = Sel_BW(self.coords, std_y, std_X, multi=True, constant=True,n_jobs=-1)
+        selector.search(multi_bw_min=[2], multi_bw_max=[159])
         model = MGWR(self.coords, std_y, std_X, selector=selector,
-                     constant=True)
+                     constant=True,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
-        rslt_2 = model.fit(n_chunks=2,
-                           pool=self.pool)  #testing for n_chunks > 1
-        rslt_3 = model.fit(n_chunks=3, pool=self.pool)
-        rslt_20 = model.fit(n_chunks=20, pool=self.pool)
+        rslt = model.fit()
+        rslt_2 = model.fit(n_chunks=2)  #testing for n_chunks > 1
+        rslt_3 = model.fit(n_chunks=3)
+        rslt_20 = model.fit(n_chunks=20)
 
         model_hat = MGWR(self.coords, std_y, std_X, selector=selector,
-                         constant=True, hat_matrix=True)
-        rslt_hat = model_hat.fit(pool=self.pool)
-        rslt_hat_2 = model_hat.fit(n_chunks=2, pool=self.pool)
+                         constant=True, hat_matrix=True,n_jobs=-1)
+        rslt_hat = model_hat.fit()
+        rslt_hat_2 = model_hat.fit(n_chunks=2)
 
         np.testing.assert_allclose(rslt_hat.R, rslt_hat_2.R, atol=1e-07)
         np.testing.assert_allclose(
@@ -275,7 +272,7 @@ class TestGWRGaussianPool(unittest.TestCase):
         coords_test = coords[test]
 
         model = GWR(self.coords, self.y, self.X, 93, family=Gaussian(),
-                    fixed=False, kernel='bisquare', sigma2_v1=False)
+                    fixed=False, kernel='bisquare', sigma2_v1=False,n_jobs=-1)
         results = model.predict(coords_test, X_test)
 
         params = np.array([
@@ -324,7 +321,7 @@ class TestGWRGaussianPool(unittest.TestCase):
         np.testing.assert_allclose(predictions, results.predictions,
                                    rtol=1e-05)
 
-    def test_BS_NN_longlat_Pool(self):
+    def test_BS_NN_longlat_Parallel(self):
         GA_longlat = os.path.join(
             os.path.dirname(__file__), 'ga_bs_nn_longlat_listwise.csv')
         self.BS_NN_longlat = io.open(GA_longlat)
@@ -357,9 +354,9 @@ class TestGWRGaussianPool(unittest.TestCase):
                                                                          1))
 
         model = GWR(coords_longlat, self.y, self.X, bw=90.000, fixed=False,
-                    spherical=True, sigma2_v1=False)
+                    spherical=True, sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -392,7 +389,7 @@ class TestGWRGaussianPool(unittest.TestCase):
         np.testing.assert_allclose(cooksD, rslt.cooksD, rtol=1e-00)
 
 
-class TestGWRPoissonPool(unittest.TestCase):
+class TestGWRPoissonParallel(unittest.TestCase):
     def setUp(self):
         data_path = os.path.join(
             os.path.dirname(__file__), 'tokyo/Tokyomortality.csv')
@@ -422,9 +419,8 @@ class TestGWRPoissonPool(unittest.TestCase):
             os.path.join(
                 os.path.dirname(__file__),
                 'tokyo/tokyo_BS_NN_OFF_listwise.csv'))
-        self.pool = mp.Pool(4)
 
-    def test_BS_F_Pool(self):
+    def test_BS_F_Parallel(self):
         est_Int = self.BS_F.by_col(' est_Intercept')
         se_Int = self.BS_F.by_col(' se_Intercept')
         t_Int = self.BS_F.by_col(' t_Intercept')
@@ -445,9 +441,9 @@ class TestGWRPoissonPool(unittest.TestCase):
 
         model = GWR(self.coords, self.y, self.X, bw=26029.625,
                     family=Poisson(), kernel='bisquare', fixed=True,
-                    sigma2_v1=False)
+                    sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -475,7 +471,7 @@ class TestGWRPoissonPool(unittest.TestCase):
         np.testing.assert_allclose(yhat, rslt.mu, rtol=1e-05)
         np.testing.assert_allclose(pdev, rslt.pDev, rtol=1e-05)
 
-    def test_BS_NN_Pool(self):
+    def test_BS_NN(self):
         est_Int = self.BS_NN.by_col(' est_Intercept')
         se_Int = self.BS_NN.by_col(' se_Intercept')
         t_Int = self.BS_NN.by_col(' t_Intercept')
@@ -495,9 +491,9 @@ class TestGWRPoissonPool(unittest.TestCase):
         pdev = np.array(self.BS_NN.by_col(' localpdev')).reshape((-1, 1))
 
         model = GWR(self.coords, self.y, self.X, bw=50, family=Poisson(),
-                    kernel='bisquare', fixed=False, sigma2_v1=False)
+                    kernel='bisquare', fixed=False, sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -527,7 +523,7 @@ class TestGWRPoissonPool(unittest.TestCase):
         np.testing.assert_allclose(yhat, rslt.mu, rtol=1e-04)
         np.testing.assert_allclose(pdev, rslt.pDev, rtol=1e-05)
 
-    def test_BS_NN_Offset_Pool(self):
+    def test_BS_NN_Offset_Parallel(self):
         est_Int = self.BS_NN_OFF.by_col(' est_Intercept')
         se_Int = self.BS_NN_OFF.by_col(' se_Intercept')
         t_Int = self.BS_NN_OFF.by_col(' t_Intercept')
@@ -548,9 +544,9 @@ class TestGWRPoissonPool(unittest.TestCase):
 
         model = GWR(self.coords, self.y, self.X, bw=100, offset=self.off,
                     family=Poisson(), kernel='bisquare', fixed=False,
-                    sigma2_v1=False)
+                    sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -595,7 +591,7 @@ class TestGWRPoissonPool(unittest.TestCase):
         np.testing.assert_allclose(yhat, rslt.mu, rtol=1e-03, atol=1e-02)
         np.testing.assert_allclose(pdev, rslt.pDev, rtol=1e-04, atol=1e-02)
 
-    def test_GS_F_Pool(self):
+    def test_GS_F_Parallel(self):
         est_Int = self.GS_F.by_col(' est_Intercept')
         se_Int = self.GS_F.by_col(' se_Intercept')
         t_Int = self.GS_F.by_col(' t_Intercept')
@@ -615,9 +611,9 @@ class TestGWRPoissonPool(unittest.TestCase):
         pdev = np.array(self.GS_F.by_col(' localpdev')).reshape((-1, 1))
 
         model = GWR(self.coords, self.y, self.X, bw=8764.474, family=Poisson(),
-                    kernel='gaussian', fixed=True, sigma2_v1=False)
+                    kernel='gaussian', fixed=True, sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -644,7 +640,7 @@ class TestGWRPoissonPool(unittest.TestCase):
         np.testing.assert_allclose(yhat, rslt.mu, rtol=1e-04)
         np.testing.assert_allclose(pdev, rslt.pDev, rtol=1e-05)
 
-    def test_GS_NN_Pool(self):
+    def test_GS_NN_Parallel(self):
         est_Int = self.GS_NN.by_col(' est_Intercept')
         se_Int = self.GS_NN.by_col(' se_Intercept')
         t_Int = self.GS_NN.by_col(' t_Intercept')
@@ -664,9 +660,9 @@ class TestGWRPoissonPool(unittest.TestCase):
         pdev = np.array(self.GS_NN.by_col(' localpdev')).reshape((-1, 1))
 
         model = GWR(self.coords, self.y, self.X, bw=50, family=Poisson(),
-                    kernel='gaussian', fixed=False, sigma2_v1=False)
+                    kernel='gaussian', fixed=False, sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -694,7 +690,7 @@ class TestGWRPoissonPool(unittest.TestCase):
         np.testing.assert_allclose(pdev, rslt.pDev, rtol=1e-05)
 
 
-class TestGWRBinomialPool(unittest.TestCase):
+class TestGWRBinomialParallel(unittest.TestCase):
     def setUp(self):
         data_path = os.path.join(
             os.path.dirname(__file__), 'clearwater/landslides.csv')
@@ -724,9 +720,8 @@ class TestGWRBinomialPool(unittest.TestCase):
             os.path.join(
                 os.path.dirname(__file__),
                 'clearwater/clearwater_GS_NN_listwise.csv'))
-        self.pool = mp.Pool(4)
 
-    def test_BS_F_Pool(self):
+    def test_BS_F_Parallel(self):
         est_Int = self.BS_F.by_col(' est_Intercept')
         se_Int = self.BS_F.by_col(' se_Intercept')
         t_Int = self.BS_F.by_col(' t_Intercept')
@@ -753,9 +748,9 @@ class TestGWRBinomialPool(unittest.TestCase):
 
         model = GWR(self.coords, self.y, self.X, bw=19642.170,
                     family=Binomial(), kernel='bisquare', fixed=True,
-                    sigma2_v1=False)
+                    sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -791,7 +786,7 @@ class TestGWRBinomialPool(unittest.TestCase):
         # code from Jing's python version, which both yield the same
         #np.testing.assert_allclose(pdev, rslt.pDev, rtol=1e-05)
 
-    def test_BS_NN_Pool(self):
+    def test_BS_NN_Parallel(self):
         est_Int = self.BS_NN.by_col(' est_Intercept')
         se_Int = self.BS_NN.by_col(' se_Intercept')
         t_Int = self.BS_NN.by_col(' t_Intercept')
@@ -817,9 +812,9 @@ class TestGWRBinomialPool(unittest.TestCase):
         pdev = self.BS_NN.by_col(' localpdev')
 
         model = GWR(self.coords, self.y, self.X, bw=158, family=Binomial(),
-                    kernel='bisquare', fixed=False, sigma2_v1=False)
+                    kernel='bisquare', fixed=False, sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -858,7 +853,7 @@ class TestGWRBinomialPool(unittest.TestCase):
         # code from Jing's python version, which both yield the same
         #np.testing.assert_allclose(pdev, rslt.pDev, rtol=1e-05)
 
-    def test_GS_F_Pool(self):
+    def test_GS_F_Parallel(self):
         est_Int = self.GS_F.by_col(' est_Intercept')
         se_Int = self.GS_F.by_col(' se_Intercept')
         t_Int = self.GS_F.by_col(' t_Intercept')
@@ -885,9 +880,9 @@ class TestGWRBinomialPool(unittest.TestCase):
 
         model = GWR(self.coords, self.y, self.X, bw=8929.061,
                     family=Binomial(), kernel='gaussian', fixed=True,
-                    sigma2_v1=False)
+                    sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)
@@ -923,7 +918,7 @@ class TestGWRBinomialPool(unittest.TestCase):
         # code from Jing's python version, which both yield the same
         #np.testing.assert_allclose(pdev, rslt.pDev, rtol=1e-05)
 
-    def test_GS_NN_Pool(self):
+    def test_GS_NN_Parallel(self):
         est_Int = self.GS_NN.by_col(' est_Intercept')
         se_Int = self.GS_NN.by_col(' se_Intercept')
         t_Int = self.GS_NN.by_col(' t_Intercept')
@@ -949,9 +944,9 @@ class TestGWRBinomialPool(unittest.TestCase):
         pdev = self.GS_NN.by_col(' localpdev')
 
         model = GWR(self.coords, self.y, self.X, bw=64, family=Binomial(),
-                    kernel='gaussian', fixed=False, sigma2_v1=False)
+                    kernel='gaussian', fixed=False, sigma2_v1=False,n_jobs=-1)
 
-        rslt = model.fit(pool=self.pool)
+        rslt = model.fit()
 
         AICc = get_AICc(rslt)
         AIC = get_AIC(rslt)

--- a/notebooks/GWR_MGWR_Parallel_Example.ipynb
+++ b/notebooks/GWR_MGWR_Parallel_Example.ipynb
@@ -1,26 +1,28 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notes:\n",
+    "- The parallelization has changed its interface, now it is using `joblib` library by specifying a `n_jobs` parameter in ,`GWR()` or `MGWR()` and `Sel_BW()`.\n",
+    "\n",
+    "- `mgwr` has soft dependency of `numba`, please install numba if you need better performance (`pip install numba`)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/Ziqi/anaconda/lib/python3.5/site-packages/libpysal/io/iohandlers/__init__.py:25: UserWarning: SQLAlchemy and Geomet not installed, database I/O disabled\n",
-      "  warnings.warn('SQLAlchemy and Geomet not installed, database I/O disabled')\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import geopandas as gp\n",
     "import multiprocessing as mp\n",
     "import libpysal as ps\n",
     "import sys\n",
-    "sys.path.append('/Users/Ziqi/Desktop/mgwr/')\n",
+    "\n",
+    "sys.path.append('/Users/ziqili/Desktop/mgwr-2')\n",
     "from mgwr.gwr import GWR,MGWR\n",
     "from mgwr.sel_bw import Sel_BW"
    ]
@@ -51,6 +53,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### GWR No Parallel (n_jobs=1)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
@@ -59,34 +68,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "env: OMP_NUM_THREADS=1\n"
-     ]
-    }
-   ],
-   "source": [
-    "#This might be needed to turn off the OpenMP multi-threading\n",
-    "%env OMP_NUM_THREADS = 1"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### GWR No Parallel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
       "192.0\n",
-      "CPU times: user 13.9 s, sys: 116 ms, total: 14 s\n",
-      "Wall time: 14.2 s\n"
+      "CPU times: user 56.2 s, sys: 1.22 s, total: 57.4 s\n",
+      "Wall time: 5.38 s\n"
      ]
     }
    ],
@@ -95,51 +79,79 @@
     "gwr_selector = Sel_BW(b_coords, b_y, b_X)\n",
     "gwr_bw = gwr_selector.search()\n",
     "print(gwr_bw)\n",
-    "gwr_results = GWR(b_coords, b_y, b_X, gwr_bw).fit()"
+    "gwr_results = GWR(b_coords, b_y, b_X, gwr_bw,n_jobs=1).fit() #n_jobs"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### MGWR No Parallel"
+    "### MGWR No Parallel (n_jobs=1)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6b17cdb5d94444769b5396723ca103e6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 191. 1279.   79. 2200.]\n",
-      "CPU times: user 3min 37s, sys: 2.73 s, total: 3min 40s\n",
-      "Wall time: 3min 18s\n"
+      "[ 191. 1279.   79. 2200.]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5449a8b043ba4df193f190d0364ce9f8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 15min 37s, sys: 51 s, total: 16min 28s\n",
+      "Wall time: 1min 24s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "mgwr_selector = Sel_BW(b_coords, b_y, b_X, multi=True)\n",
+    "mgwr_selector = Sel_BW(b_coords, b_y, b_X, multi=True,n_jobs=1)\n",
     "mgwr_bw = mgwr_selector.search()\n",
     "print(mgwr_bw)\n",
-    "mgwr_results = MGWR(b_coords, b_y, b_X, selector=mgwr_selector).fit()"
+    "mgwr_results = MGWR(b_coords, b_y, b_X, selector=mgwr_selector,n_jobs=1).fit()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "#Parrallelization is more favored when you your data are large and/or your machine have many many cores.\n",
-    "#mgwr has soft dependency of numba, please install numba if you need better performance (pip install numba).\n",
-    "\n",
-    "n_proc = 2 #two processors\n",
-    "pool = mp.Pool(n_proc) "
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -150,7 +162,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#n_jobs = 2 #two processors\n",
+    "n_jobs = -1 #all processors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -158,17 +180,78 @@
      "output_type": "stream",
      "text": [
       "192.0\n",
-      "CPU times: user 303 ms, sys: 42.3 ms, total: 346 ms\n",
-      "Wall time: 7.05 s\n"
+      "CPU times: user 1.34 s, sys: 403 ms, total: 1.74 s\n",
+      "Wall time: 3.6 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "gwr_selector = Sel_BW(b_coords, b_y, b_X)\n",
-    "gwr_bw = gwr_selector.search(pool=pool) #add pool to Sel_BW.search\n",
+    "gwr_selector = Sel_BW(b_coords, b_y, b_X,n_jobs=n_jobs) #add n_jobs to Sel_BW()\n",
+    "gwr_bw = gwr_selector.search() #add pool to Sel_BW.search\n",
     "print(gwr_bw)\n",
-    "gwr_results = GWR(b_coords, b_y, b_X, gwr_bw).fit(pool=pool) #add pool to GWR.fit"
+    "gwr_results = GWR(b_coords, b_y, b_X, gwr_bw,n_jobs=n_jobs).fit() #add n_jobs to GWR()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Effectivenss of `n_jobs`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 1.0, 'GWR Performance with Different n_jobs Values')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjcAAAHHCAYAAABDUnkqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABraUlEQVR4nO3deVhUZf8G8HvYBtkF2VRExAUQVNQ0cEFTc1fU1MjC3szKNDOtjF+LSyVpaVmZ61uWZot7WqKm5oororjkioDIoiI7DMs8vz+QeR0BZWCGMzPcn+s6l86Z55z5zgJzc85znkcmhBAgIiIiMhImUhdAREREpE0MN0RERGRUGG6IiIjIqDDcEBERkVFhuCEiIiKjwnBDRERERoXhhoiIiIwKww0REREZFYYbIiIiMioMN1QvRUVFoUOHDrC0tIRMJkNmZqbUJdU7vXr1Qq9evard1t/fX7cFPUQmk2H27Nlq606cOIHg4GBYW1tDJpMhNjYWAD9P1TF79mzIZLIabdu8eXMMGTJEyxXpVmWfH6o7DDdGKj4+HlOmTEHr1q1hZWUFKysr+Pn5YfLkyTh79qyq3YIFCyCTyXD69Gm17YUQaNiwIWQyGeLj49XuKywshFwux3PPPadaJ5PJ1BY7OzuEhITgzz//rFa9N27cUNve1NQUzZo1w4gRI1RfINpy9+5djBkzBg0aNMCSJUuwZs0aWFtba/UxSHO3bt3C7Nmztf5+A2VfjuWfLRMTEzg4OCAgIACvvPIKjh07Vq19FBcXY/To0cjIyMCXX36JNWvWwNPT06A+T7p8jQ3V1KlTIZPJcPXq1SrbvP/++5DJZGq/O0nPCTI627ZtE1ZWVsLOzk5MmjRJLFu2TKxYsUJMnz5dNG/eXMhkMnHjxg0hhBCHDx8WAMTXX3+tto+4uDgBQJiZmYk1a9ao3XfgwAEBQCxZskS1DoDo16+fWLNmjfjpp5/Exx9/LBo3bixkMpmIiop6bM3x8fECgAgLCxNr1qwRq1evFjNnzhR2dnZCLpeL06dP1/6FuW/Hjh0CgNi9e7fW9kmaUygUQqFQqG6fOHFCABA//PBDhbYhISGibdu2NX4sT09P0aFDB7FmzRqxZs0a8d1334k33nhDuLm5CQDirbfeqrBNQUGBKC4uVt2+ePGiACBWrlyp1s6QPk+Peo11rbi4WBQUFNRoW09PTzF48GAtV1Tm6NGjAoCYM2dOlW28vLxEQECARvsFIGbNmlXL6qimzCRJVKQz165dw7PPPgtPT0/s2bMH7u7uavfPnz8f3333HUxMyg7ade7cGZaWljh06BDeeOMNVbvDhw/DyckJnTt3xqFDh/D888+r7jt06BAAoHv37mr7bt26tVq7UaNGwc/PD4sXL0b//v2rVX/Hjh3V9tGtWzcMGzYMS5cuxfLly6v5KlQuLy8P1tbWSE9PBwA4ODjUan+V7Zuqz8LCok4fr0mTJmqfLaDs5+G5557Dl19+iVatWmHSpEmq+ywtLdXaVvW54eepeszMzGBmpn9fOV27dkXLli3xyy+/4KOPPqpwf3R0NOLj4/HZZ59JUB3VmNTpirTrlVdeEQDE0aNHq71Njx49RJMmTdTWvfDCC2LIkCFi7ty5wt/fX+2+wYMHCwcHB1FaWqpaB0BMnjy5wr4bNWokWrdu/dgayo/cfP7552rrc3NzVUeFyh09elT0799f2NnZiQYNGoiePXuKQ4cOqW03a9YsAUCcP39ehIWFCQcHB9GhQwcREhIiAKgt48ePV233+++/i44dOwpLS0vh5OQkxo0bJ27evKm27/Hjxwtra2tx9epVMXDgQGFjYyOGDx+u9jr8/vvvwtfXV1haWoonn3xSnD17VgghxLJly4S3t7eQy+UiJCRExMfHq+37wIED4plnnhEeHh7CwsJCNG3aVEybNk3k5+dXWsPNmzfF8OHDhbW1tWjUqJGYMWOGKCkpUWtbWloqvvrqK+Hv7y/kcrlo1KiR6N+/vzhx4oRauzVr1qiee8OGDcXYsWNFYmLiI9+3M2fOCABi69atqnUnT54UAERgYKBa2wEDBoguXbqoboeEhIiQkBAhhBD79u2r8L7ggSMM5Uduzp8/L3r16iUaNGggGjduLObPn//I+so96i//nJwc4ejoKJo0aSKUSqVqPR74y3v8+PEVaiuv/1Gfp9p8VstV532pzuvzuNe4MuW1XblyRYwfP17Y29sLOzs78eKLL4q8vLzHveyV7utBxcXFYu7cuaJFixbCwsJCeHp6ioiICFFYWKjWrvz927lzp2jfvr2Qy+XC19dXbNy4Ua1dUVGRmD17tmjZsqWQy+XC0dFRdOvWTezatatatZ06darCfVOmTBEymUwkJCQIhUIhPvzwQ9GxY0dhZ2cnrKysRPfu3cXevXsrbPfg50eIss+Qp6dntV4XIar3vl++fFmMHDlSuLq6CrlcLpo0aSLGjh0rMjMzH/l86wP2uTEy27dvR8uWLdG1a9dqb9O9e3ckJyfjxo0bqnWHDx9GcHAwgoODcf78eVUHSSEEjhw5gqCgINXRn6pkZWXh3r17aNiwYU2eCoCyI1EA4OTkBADYu3cvevbsiezsbMyaNQvz5s1DZmYmnnrqKRw/frzC9qNHj0Z+fj7mzZuHiRMn4v3338crr7wCAJg7dy7WrFmDV199FQCwevVqjBkzBqampoiMjMTEiROxadMmdO/evUIH0ZKSEvTv3x8uLi744osvMGrUKNV9Bw8exIwZMzB+/HjMnj0bFy9exJAhQ7BkyRJ8/fXXeP311/HOO+8gOjoaL730ktp+169fj/z8fEyaNAnffPMN+vfvj2+++Qbh4eEVnltpaSn69+8PJycnfPHFFwgJCcHChQuxYsUKtXYTJkzAtGnT4OHhgfnz5+O9996DpaUljh49qmrz6aefIjw8HK1atcKiRYswbdo07NmzBz179nxk51h/f384ODjgwIEDas/fxMQEZ86cQXZ2NgBAqVTiyJEj6NmzZ6X78fX1xdy5cwEAr7zyCtasWYM1a9aotb937x4GDBiA9u3bY+HChfDx8cHMmTOxY8eOKuurDhsbG4wYMQLJycm4cOFCpW1effVV/N///R+Asj4aa9aswfvvv//Iz1NtP6uAZu/L416f6rzGVRkzZgxycnIQGRmJMWPGYPXq1ZgzZ041Xt1He/nll/HRRx+hY8eO+PLLLxESEoLIyEg8++yzFdpeuXIFY8eOxcCBAxEZGQkzMzOMHj0au3fvVrWZPXs25syZg969e+Pbb7/F+++/j2bNmiEmJuaRdYwbNw4AsG7dOrX1paWl+P3339GjRw80a9YM2dnZWLVqFXr16oX58+dj9uzZuH37Nvr376/VfkzVed+LiorQv39/HD16FG+88QaWLFmCV155BdevX2eHdoBHboxJVlaWACBCQ0Mr3Hfv3j1x+/Zt1fLgkYA///xTAFD1rUlJSREAxP79+0VOTo4wNTUVf/75pxBCiHPnzgkA4tNPP1XbPwAxYcIEcfv2bZGeni5OnjwpBgwYUOnRmMqUH7mZM2eOuH37tkhNTRX//POPCAwMFADExo0bhVKpFK1atRL9+/dX+ws7Pz9feHl5qR3dKf9rKCwsrMJj/fDDDwKA2pGLoqIi4eLiIvz9/dX6BWzfvl0AEB999JFqXflf8e+9916FfQMQcrlc7YjM8uXLBQDh5uYmsrOzVesjIiIEALW2Dx+hEUKIyMhI1V+OD9cwd+5ctbaBgYGiU6dOqtt79+4VAMTUqVMr7Lf8Nbxx44YwNTWt8J7GxcUJMzOzCusfNnjwYLUjMiNHjhQjR44UpqamYseOHUIIIWJiYioc4XnwyI0Qj+9zA0D89NNPqnUKhUK4ubmJUaNGPbI+IR7fZ+PLL7+sUB8e+su7/MjH+vXr1bat7POkjc+qJu9LdV8fTfvclNf20ksvqa0fMWKEcHJyqtY+Ht5XudjYWAFAvPzyy2rt3n77bQFA7WiIp6en6vdAuaysLOHu7q52hLB9+/Y17pvzxBNPiKZNm6odkY6KihIAxPLly4UQQpSUlKj1ExOi7Herq6trhdfo4c9PdY/cVPd9P336dKWfRyrDIzdGpPyvZBsbmwr39erVC87OzqplyZIlqvuCg4NhYmKi6ktz+PBhmJub44knnoCNjQ3atWuHw4cPq+4DKva3AYD//ve/cHZ2houLCzp37ow9e/bg3XffxfTp06v9HGbNmgVnZ2e4ubmhV69euHbtGubPn4+RI0ciNjYWV65cwXPPPYe7d+/izp07uHPnDvLy8tCnTx8cOHAASqVSbX+vvfZatR735MmTSE9Px+uvv67W12Lw4MHw8fGp9KqvB/tnPKhPnz5o3ry56nb5UbRRo0bB1ta2wvrr16+r1jVo0ED1/7y8PNy5cwfBwcEQQlS4oq2y59ejRw+1/W3cuBEymQyzZs2qsG35ZbmbNm2CUqnEmDFjVK/pnTt34ObmhlatWmHfvn2VPs8HHzMmJgZ5eXkAyvpkDRo0CB06dMDBgwcBlB3NkclklX5uqsvGxkatz4yFhQW6dOmi9nxrs28AyMnJqfW+AGjls6rp+6LL16eyz9ndu3dVv3Nq4q+//gKACr8fZsyYAQAVfuYaN26MESNGqG7b2dkhPDwcp0+fRmpqKoCyfk/nz5/HlStXNK7n+eefx82bN9WOQq5btw4WFhYYPXo0AMDU1FTVV0ypVCIjIwMlJSXo3LnzY48OVVd133d7e3sAwM6dO5Gfn6+VxzYm+te7i2qs/IszNze3wn3Lly9HTk4O0tLSKnSqdHBwQNu2bdUCTGBgoOqLNjg4WO2+8l+aDxs+fDimTJmCoqIinDhxAvPmzUN+fv5jT1896JVXXsHo0aNVl+u2bdsWcrkcAFS/sMaPH1/l9llZWWqnwby8vKr1uAkJCQCANm3aVLjPx8dHFfzKmZmZoWnTppXuq1mzZmq3y38JeXh4VLr+3r17qnWJiYn46KOP8Mcff6itB8qe24MsLS3h7Oystq5hw4Zq2127dg2NGzeGo6NjpbUCZa+rEAKtWrWq9H5zc/MqtwXKvuhKSkoQHR0NDw8PpKeno0ePHjh//rxauPHz83tkHY/TtGnTCuOkNGzYUCuX55b/zDwYPmtDG59VTd8XXb4+D3+my+u+d+8e7OzsarTPhIQEmJiYoGXLlmrr3dzc4ODgoPqZLNeyZcsKz69169YAyoaScHNzw9y5czF8+HC0bt0a/v7+GDBgAF544QW0a9fusfU8++yzmD59OtatW4devXqhsLAQmzdvxsCBA9Xepx9//BELFy7Ev//+i+LiYtX66v6ueZzqvu9eXl6YPn06Fi1ahJ9//hk9evTAsGHD8Pzzz6t+t9RnDDdGxN7eHu7u7jh37lyF+8qPEjzYr+ZB3bt3x7Jly5CZmanqb1MuODgY33//PYqLi3Ho0CF06tSpwpUkQNkv1759+wIABg0ahEaNGmHKlCno3bs3Ro4cWa3n0KpVK9U+Hlb+l+7nn3+ODh06VNrm4aNWDx4J0Sa5XF5laDM1NdVovRACQNn5/X79+iEjIwMzZ86Ej48PrK2tkZycjBdffLHCX/pV7U9TSqUSMpkMO3bsqHSflR0JfFD5FXcHDhxAs2bN4OLigtatW6NHjx747rvvoFAocPDgQbW/umvica9fbZT/zDz8RVtT2visavq+6PL10eW+azqwX2V69uyJa9euYevWrdi1axdWrVqFL7/8EsuWLcPLL7/8yG1dXFzQr18/bNy4EUuWLMG2bduQk5Oj6o8DAGvXrsWLL76I0NBQvPPOO3BxcVH10SvvH1iVqp5naWmp2m1N3veFCxfixRdfVD3fqVOnIjIyEkePHq3yj6/6guHGyAwePBirVq3C8ePHKz26UpXu3btj6dKl+Pvvv3H69Gm88847qvuCg4NRUFCAP//8E9evX1frPPsor776Kr788kt88MEHGDFiRK1/iXl7ewMoOxxdVQCqKU9PTwDApUuX8NRTT6ndd+nSJdX9uhQXF4fLly/jxx9/VOtA/GCHSU15e3tj586dyMjIqPKoibe3N4QQ8PLyUv0lrInyI3kHDx5Es2bN0KNHDwBlR3QUCgV+/vlnpKWlPbbjqja/5DSRm5uLzZs3w8PDA76+vlrZpzY+q7V9Xyoj1WtcGU9PTyiVSly5ckXtdU9LS0NmZmaFn7mrV69CCKH2HC5fvgwAaqeBHR0d8Z///Af/+c9/kJubi549e2L27NmPDTdAWcfiqKgo7NixA+vWrYOdnR2GDh2qun/Dhg1o0aIFNm3apFZHZad9H9awYcNKO/o+fIRK0/c9ICAAAQEB+OCDD3DkyBF069YNy5YtwyeffPLYbY0Z+9wYmXfffRdWVlZ46aWXkJaWVuH+qv7SKu8LsWjRIhQXF6sduWnevDnc3d2xYMECtbaPY2ZmhhkzZuDixYvYunWrpk+lgk6dOsHb2xtffPFFpafebt++XeN9d+7cGS4uLli2bBkUCoVq/Y4dO3Dx4kUMHjy4xvuurvK/0h58j4QQWLx4cY33OWrUKAghKr2ypfxxRo4cCVNTU8yZM6fC50MIgbt37z72cXr06IFjx45h3759qnDTqFEj+Pr6Yv78+ao2j1I+rktdXulRUFCAF154ARkZGapRaLVBG59VbbwvD5PiNa7KoEGDAABfffWV2vpFixYBQIWfuVu3bmHz5s2q29nZ2fjpp5/QoUMHuLm5AUCF18TGxgYtW7ZU+5l+lNDQUFhZWeG7777Djh07MHLkSLWj1JX9jB47dgzR0dGP3be3tzeysrLUThOmpKSoPSeg+u97dnY2SkpK1O4PCAiAiYlJtZ+vMeORGyPTqlUrrFu3DmFhYWjTpg3GjRuH9u3bQwiB+Ph4rFu3DiYmJhUOWTZr1gweHh6Ijo5G8+bN0bhxY7X7g4ODVZ1Tu3XrVu16XnzxRXz00UeYP38+QkNDa/XcTExMsGrVKgwcOBBt27bFf/7zHzRp0gTJycnYt28f7OzssG3bthrt29zcHPPnz8d//vMfhISEICwsDGlpaVi8eDGaN2+Ot956q1a1V4ePjw+8vb3x9ttvIzk5GXZ2dti4cWOFvjea6N27N1544QV8/fXXuHLlCgYMGAClUomDBw+id+/emDJlCry9vfHJJ58gIiICN27cQGhoKGxtbREfH4/NmzfjlVdewdtvv/3Ix+nRowc+/fRTJCUlqYWYnj17Yvny5WjevPljD5N7e3vDwcEBy5Ytg62tLaytrdG1a1et9WVITk7G2rVrAZQdrblw4QLWr1+P1NRUzJgxQ3UJtzZo47Oqjfelsn3q8jXWRPv27TF+/HisWLECmZmZCAkJwfHjx/Hjjz8iNDQUvXv3VmvfunVrTJgwASdOnICrqyu+//57pKWl4YcfflC18fPzQ69evdCpUyc4Ojri5MmT2LBhA6ZMmVKtmmxsbBAaGqq6JPzBU1IAMGTIEGzatAkjRozA4MGDER8fj2XLlsHPz6/SEPugZ599FjNnzsSIESMwdepU5OfnY+nSpWjdurVaZ+Tqvu979+7FlClTMHr0aLRu3RolJSVYs2YNTE1Nq3103ajV2XVZVKeuXr0qJk2aJFq2bCksLS1FgwYNhI+Pj3jttddEbGxspduEhYUJAOK5556rcN+iRYsEAOHr61vptqhiED8hhJg9e7YAIPbt21dlvVUN4leZ06dPi5EjRwonJychl8uFp6enGDNmjNizZ4+qTfnllbdv366wfWWX7pb77bffRGBgoGoAsEcN4leZyl6Hqp5bZZcWX7hwQfTt21fY2NiIRo0aiYkTJ6oGynvw8t2qaqhsQLCSkhLx+eefCx8fH2FhYSGcnZ3FwIEDKwxYtnHjRtG9e3dhbW0trK2thY+Pj5g8ebK4dOlSpc/1QdnZ2cLU1FTY2tqqDSK4du1aAUC88MILFbZ5+FJwIYTYunWr8PPzE2ZmZpUO4vewqi6vfVj5pcQAhEwmE3Z2dqJt27Zi4sSJ4tixY5Vug1pcCl6utp9VIar3vmjy+lT1GlemqtrKn/PDg1A+SlWD+M2ZM0d4eXkJc3Nz4eHh8dhB/Nq1ayfkcrnw8fGp8F588sknokuXLsLBwUH1O+/TTz8VRUVF1a6zfGgMd3d3tcvChSi7xH/evHnC09NTyOVyERgYKLZv317p6/zw50cIIXbt2iX8/f2FhYWFaNOmjVi7dm2Vg/g97n2/fv26eOmll4S3t7ewtLQUjo6Oonfv3uLvv/+u9nM1ZjIhtNAjjIiI6BE+/PBDREZGVjiVQqQL7HNDREQ6l5KSgkaNGkldBtUT7HNDREQ1lpWVhYKCgirvv379OqKjo7F+/XoMGTKkDiuj+oynpYiIqMZefPFF/Pjjj49sY2tri169emHlypVwdXWto8qoPmO4ISKiGrtw4QJu3br1yDbaHpeK6HEYboiIiMiosEMxERERGZV616FYqVTi1q1bsLW11auhyImIiKhqQgjk5OSgcePGj5+QWbIRdsT/BnV6cGnTpk2V7csHjnpwkcvlGj1mUlJShX1w4cKFCxcuXAxjSUpKeux3veRHbtq2bYu///5bddvM7NEl2dnZ4dKlS6rbmh59sbW1BQAkJSXBzs5Oo22JiIhIGtnZ2fDw8FB9jz+K5OHGzMxMNelZdchkMo3aV7Y9UBaSGG6IiIgMS3UOakjeofjKlSto3LgxWrRogXHjxiExMfGR7XNzc+Hp6QkPDw8MHz4c58+ff2R7hUKB7OxstYWIiIiMl6ThpmvXrli9ejWioqKwdOlSxMfHo0ePHsjJyam0fZs2bfD9999j69atWLt2LZRKJYKDg3Hz5s0qHyMyMhL29vaqxcPDQ1dPh4iIiPSAXo1zk5mZCU9PTyxatAgTJkx4bPvi4mL4+voiLCwMH3/8caVtFAoFFAqF6nb5ObusrCyeliIiIjIQ2dnZsLe3r9b3t+R9bh7k4OCA1q1b4+rVq9Vqb25ujsDAwEe2l8vlkMvl2iqRiIiI9JzkfW4elJubi2vXrsHd3b1a7UtLSxEXF1ft9kRERGT8JA03b7/9Nvbv348bN27gyJEjGDFiBExNTREWFgYACA8PR0REhKr93LlzsWvXLly/fh0xMTF4/vnnkZCQgJdfflmqp0BERER6RtLTUjdv3kRYWBju3r0LZ2dndO/eHUePHoWzszMAIDExUW0Uwnv37mHixIlITU1Fw4YN0alTJxw5cgR+fn5SPQUiIiLSM3rVobguaNIhiYiIiPSDJt/fetXnhoiIiKi29OpqKUNWqhQ4Hp+B9JxCuNhaoouXI0xNODEnERFRXWO40YKocymYs+0CUrIKVevc7S0xa6gfBvjzSi4iIqK6xNNStRR1LgWT1saoBRsASM0qxKS1MYg6lyJRZURERPUTw00tlCoF5my7gMp6ZJevm7PtAkqV9arPNhERkaQYbmrheHxGhSM2DxIAUrIKcTw+o+6KIiIiqucYbmohPafqYFOTdkRERFR7DDe14GJrqdV2REREVHsMN7XQxcsR7vaWqOqCbxnKrprq4uVYl2URERHVaww3tWBqIsOsoWVTP1QVcGYN9eN4N0RERHWI4aaWBvi7Y+nzHeFmr37qydLMBEuf78hxboiIiOoYB/HTggH+7ujn54bj8RmITbqH+VGXUKJUoquXk9SlERER1Ts8cqMlpiYyBHk7YVKvlvBzt0OJEth+9pbUZREREdU7DDc6MLJjEwDAhphkiSshIiKqfxhudGB4hyYwNZHhTFImrqbnSl0OERFRvcJwowPOtnKEtHYGAGyKuSlxNURERPULw42OjOrYFACw+XQylJxbioiIqM4w3OhIH18X2FmaISWrENHX70pdDhERUb3BcKMjluamGNK+MQBgI09NERER1RmGGx0adf+qqahzqchTlEhcDRERUf3AcKNDHZs1RHMnK+QXlSLqXKrU5RAREdULDDc6JJPJMPJ+x2KemiIiIqobDDc6NiKw7NRU9PW7SM4skLgaIiIi48dwo2Mejlbo6uUIIYAtpzliMRERka4x3NSBUZ3+d2pKCI55Q0REpEsMN3VgoL8bLM1NcP12HmKTMqUuh4iIyKgx3NQBW0tzDGjrBgDYxMk0iYiIdIrhpo6Un5r648wtKEpKJa6GiIjIeDHc1JFg70Zws7NEVkEx9v2bLnU5RERERovhpo6YmsgQev+y8A2neGqKiIhIVxhu6lD5dAz/XErH3VyFxNUQEREZJ4abOtTK1RbtmtqjRCnwx5lbUpdDRERklCQNN7Nnz4ZMJlNbfHx8HrnN+vXr4ePjA0tLSwQEBOCvv/6qo2q1Y+T9U1O8aoqIiEg3JD9y07ZtW6SkpKiWQ4cOVdn2yJEjCAsLw4QJE3D69GmEhoYiNDQU586dq8OKa2dYhyYwM5EhLjkLl9NypC6HiIjI6EgebszMzODm5qZaGjVqVGXbxYsXY8CAAXjnnXfg6+uLjz/+GB07dsS3335bhxXXjqO1BXr7uADgZJpERES6IHm4uXLlCho3bowWLVpg3LhxSExMrLJtdHQ0+vbtq7auf//+iI6O1nWZWjXq/kzhW04no1TJ6RiIiIi0SdJw07VrV6xevRpRUVFYunQp4uPj0aNHD+TkVH66JjU1Fa6urmrrXF1dkZqaWuVjKBQKZGdnqy1S6+3jDAcrc6RlK3Do6h2pyyEiIjIqkoabgQMHYvTo0WjXrh369++Pv/76C5mZmfj999+19hiRkZGwt7dXLR4eHlrbd03JzUwxrH1jAMAmnpoiIiLSKslPSz3IwcEBrVu3xtWrVyu9383NDWlpaWrr0tLS4ObmVuU+IyIikJWVpVqSkpK0WnNNjbx/amrn+VTkFBZLXA0REZHx0Ktwk5ubi2vXrsHd3b3S+4OCgrBnzx61dbt370ZQUFCV+5TL5bCzs1Nb9EH7pvbwdrZGYbESO+KqPq1GREREmpE03Lz99tvYv38/bty4gSNHjmDEiBEwNTVFWFgYACA8PBwRERGq9m+++SaioqKwcOFC/Pvvv5g9ezZOnjyJKVOmSPUUakwmk6mO3mzgqSkiIiKtkTTc3Lx5E2FhYWjTpg3GjBkDJycnHD16FM7OzgCAxMREpKSkqNoHBwdj3bp1WLFiBdq3b48NGzZgy5Yt8Pf3l+op1MqIwCaQyYDj8RlIysiXuhwiIiKjIBNC1KtrkbOzs2Fvb4+srCy9OEU1btVRHL56F2/1bY03+7aSuhwiIiK9pMn3t171uamPyse82XT6JupZziQiItIJhhuJ9W/rBisLUyTczcephHtSl0NERGTwGG4kZi03w0D/sqvDNnIyTSIiolpjuNEDozqWzRS+/ewtFBaXSlwNERGRYWO40QNPtnBCE4cGyCkswd8X0x6/AREREVWJ4UYPmJjIMCKw7OjNxlMc84aIiKg2GG70xIj7p6YOXLmD9JxCiashIiIyXAw3esLb2QaBzRxQqhT4I/aW1OUQEREZLIYbPVI+HQOvmiIiIqo5hhs9MrSdOyxMTXAxJRsXbmVLXQ4REZFBYrjRIw5WFujj6wIA2MTJNImIiGqE4UbPlE/HsCX2FkpKlRJXQ0REZHgYbvRMSBtnOFlb4E6uAgev3JG6HCIiIoPDcKNnzE1NMKxDYwDABp6aIiIi0hjDjR4qPzW1+0IasgqKJa6GiIjIsDDc6KG2je3QxtUWRSVK/Hk2RepyiIiIDArDjR6SyWQYeX/EYl41RUREpBmGGz0VGtgEJjLgZMI93LiTJ3U5REREBoPhRk+52lmieytnAMCm0xyxmIiIqLoYbvTYqAdOTSmVQuJqiIiIDAPDjR572s8NNnIz3LxXgOM3MqQuh4iIyCAw3OixBhamGBzgDoAdi4mIiKqL4UbPlV819VdcKgqKSiWuhoiISP8x3Oi5J5o7wsOxAXIVJdh1IVXqcoiIiPQew42eMzGRYURg2YjFG07x1BQREdHjMNwYgPKrpg5fvYPUrEKJqyEiItJvDDcGwNPJGk80bwilALbEcswbIiKiR2G4MRAj70+mufHUTQjBMW+IiIiqwnBjIAa3c4eFmQmupOfiXHK21OUQERHpLYYbA2FnaY6n/VwBABs55g0REVGVGG4MyKhOZaem/jhzC0UlSomrISIi0k8MNwakR8tGcLaVIyOvCPsv35a6HCIiIr3EcGNAzExNENqhMYCyjsVERERUkd6Em88++wwymQzTpk2rss3q1ashk8nUFktLy7orUg+UXzW15980ZOYXSVwNERGR/tGLcHPixAksX74c7dq1e2xbOzs7pKSkqJaEhIQ6qFB/+Lrbwc/dDsWlAtvO3JK6HCIiIr0jebjJzc3FuHHjsHLlSjRs2PCx7WUyGdzc3FSLq6trHVSpX8on09wYwwH9iIiIHiZ5uJk8eTIGDx6Mvn37Vqt9bm4uPD094eHhgeHDh+P8+fOPbK9QKJCdna22GLrhHZrA1ESG2KRMXLudK3U5REREekXScPPrr78iJiYGkZGR1Wrfpk0bfP/999i6dSvWrl0LpVKJ4OBg3LxZdefayMhI2NvbqxYPDw9tlS8ZZ1s5Qlo7AwA2ccwbIiIiNZKFm6SkJLz55pv4+eefq90pOCgoCOHh4ejQoQNCQkKwadMmODs7Y/ny5VVuExERgaysLNWSlJSkracgqVH3OxZvjkmGUsnpGIiIiMqZSfXAp06dQnp6Ojp27KhaV1paigMHDuDbb7+FQqGAqanpI/dhbm6OwMBAXL16tco2crkccrlca3Xriz6+LrCzNMOtrEIcvX4XwS0bSV0SERGRXpDsyE2fPn0QFxeH2NhY1dK5c2eMGzcOsbGxjw02QFkYiouLg7u7ex1UrF8szU0xpH3ZmDcbeGqKiIhIRbJwY2trC39/f7XF2toaTk5O8Pf3BwCEh4cjIiJCtc3cuXOxa9cuXL9+HTExMXj++eeRkJCAl19+WaqnIalR96+aijqXijxFicTVEBER6QfJr5Z6lMTERKSkpKhu37t3DxMnToSvry8GDRqE7OxsHDlyBH5+fhJWKZ2OzRqiuZMV8otKEXUuVepyiIiI9IJMCFGveqNmZ2fD3t4eWVlZsLOzk7qcWvt6zxUs2n0Z3Vo64eeXn5S6HCIiIp3Q5Ptbr4/c0OONCCw7NXXk2l3cyiyQuBoiIiLpMdwYOA9HK3T1coQQwObTHLGYiIiI4cYIjOpUNubNxpibqGdnGYmIiCpguDECgwLcYWluguu38xCblCl1OURERJJiuDECNnIzDGjrBgDYxMk0iYionmO4MRLlp6b+OHMLipJSiashIiKSDsONkQj2bgQ3O0tkFRRj37/pUpdDREQkGYYbI2FqIkPo/cvCN5ziqSkiIqq/GG6MSPl0DP9cSsfdXIXE1RAREUmD4caItHK1Rbum9ihRCvxx5pbU5RAREUmC4cbIjLx/aopXTRERUX3FcGNkhnVoAjMTGeKSs3A5LUfqcoiIiOocw42RcbS2QG8fFwBlIxYTERHVNww3RmhUx7Ixb7acTkapktMxEBFR/WKmSWOlUon9+/fj4MGDSEhIQH5+PpydnREYGIi+ffvCw8NDV3WSBnr7OMPByhxp2QocvnoHPVs7S10SERFRnanWkZuCggJ88skn8PDwwKBBg7Bjxw5kZmbC1NQUV69exaxZs+Dl5YVBgwbh6NGjuq6ZHkNuZoph7RsD4KkpIiKqf6p15KZ169YICgrCypUr0a9fP5ibm1dok5CQgHXr1uHZZ5/F+++/j4kTJ2q9WKq+kR2b4qfoBOw8n4qcwmLYWlZ8z4iIiIyRTAjx2E4ZFy9ehK+vb7V2WFxcjMTERHh7e9e6OF3Izs6Gvb09srKyYGdnJ3U5OiOEQN9F+3Htdh4WjGqHMU/wlCERERkuTb6/q3VaqrrBBgDMzc31NtjUJzKZDCPvdyzmqSkiIqpPNL5aKioqCocOHVLdXrJkCTp06IDnnnsO9+7d02pxVDsjAptAJgOOxWcgKSNf6nKIiIjqhMbh5p133kF2djYAIC4uDjNmzMCgQYMQHx+P6dOna71AqrnGDg0Q7O0EANh8miMWExFR/aBxuImPj4efnx8AYOPGjRgyZAjmzZuHJUuWYMeOHVovkGqnfMybTTE3UY3uVURERAZP43BjYWGB/PyyUxx///03nn76aQCAo6Oj6ogO6Y/+bd1gZWGKG3fzEZPI04ZERGT8NA433bt3x/Tp0/Hxxx/j+PHjGDx4MADg8uXLaNq0qdYLpNqxlpthoL87AGDDKZ6aIiIi46dxuPn2229hZmaGDRs2YOnSpWjSpGwW6h07dmDAgAFaL5Bqb1Snsvdo+9lbKCwulbgaIiIi3arWODfGpL6Mc/MgpVKgx4J9SM4swNQ+LeHtbAMXW0t08XKEqYlM6vKIiIgeS5Pv72qNUKxJX5r6EhgMiYmJDO2a2iM5swBf77mqWu9ub4lZQ/0w4P5pKyIiImNQrXDj4OAAmax6f+GXlvK0h76JOpeCHedSK6xPzSrEpLUxWPp8RwYcIiIyGtUKN/v27VP9/8aNG3jvvffw4osvIigoCAAQHR2NH3/8EZGRkbqpkmqsVCkwZ9uFSu8TAGQA5my7gH5+bjxFRURERqFa4SYkJET1/7lz52LRokUICwtTrRs2bBgCAgKwYsUKjB8/XvtVUo0dj89ASlZhlfcLAClZhTgen4Gg+wP+ERERGTKNr5aKjo5G586dK6zv3Lkzjh8/rpWiSHvSc6oONjVpR0REpO80DjceHh5YuXJlhfWrVq2ChwdnntY3LraWWm1HRESk76p1WupBX375JUaNGoUdO3aga9euAIDjx4/jypUr2Lhxo9YLpNrp4uUId3tLpGYVorJr/mUA3OzLLgsnIiIyBhofuRk0aBCuXLmCoUOHIiMjAxkZGRg6dCguX76MQYMG1biQzz77DDKZDNOmTXtku/Xr18PHxweWlpYICAjAX3/9VePHrA9MTWSYNbRsLrCqugvPGurHzsRERGQ0ND5yAwBNmzbFvHnztFbEiRMnsHz5crRr1+6R7Y4cOYKwsDBERkZiyJAhWLduHUJDQxETEwN/f3+t1WNsBvi7Y+nzHTFn24UKnYtnD2vLy8CJiMio1GiE4szMTBw/fhzp6elQKpVq94WHh2u0r9zcXHTs2BHfffcdPvnkE3To0AFfffVVpW3Hjh2LvLw8bN++XbXuySefRIcOHbBs2bJqPV59HKG4XKlS4Hh8BtJzCrH68A2cTsrEc12bYd6IAKlLIyIieiStj1D8oG3btmHcuHHIzc2FnZ2d2uB+MplM43AzefJkDB48GH379sUnn3zyyLbR0dGYPn262rr+/ftjy5YtVW6jUCigUChUt+vzzOWmJjLV5d7u9g0wZnk0Npy6ibf6toazrVzi6oiIiLRD4z43M2bMwEsvvYTc3FxkZmbi3r17qiUjI0Ojff3666+IiYmp9uB/qampcHV1VVvn6uqK1NSKo++Wi4yMhL29vWrhFV1lnmjeEIHNHFBUosTqI/FSl0NERKQ1Goeb5ORkTJ06FVZWVrV64KSkJLz55pv4+eefYWmpu8uQIyIikJWVpVqSkpJ09liGRCaT4dWe3gCANdEJyFWUSFwRERGRdmgcbvr374+TJ0/W+oFPnTqF9PR0dOzYEWZmZjAzM8P+/fvx9ddfw8zMrNI5qtzc3JCWlqa2Li0tDW5ublU+jlwuh52dndpCZZ72c0WLRtbILizBr8cTpS6HiIhIKzTuczN48GC88847uHDhAgICAmBubq52/7Bhw6q1nz59+iAuLk5t3X/+8x/4+Phg5syZMDU1rbBNUFAQ9uzZo3a5+O7du1VzXJFmTExkeKVnC7y3KQ7/PRSP8cHNYW6qcd4lIiLSKxpfLWViUvWXn0wmq9Ws4L169VK7Wio8PBxNmjRR9ck5cuQIQkJC8Nlnn2Hw4MH49ddfMW/ePI0uBa/PV0tVprC4FD0W7MPtHAUWjm6PUZ2aSl0SERFRBZp8f2v8Z7pSqaxyqU2wqUxiYiJSUlJUt4ODg7Fu3TqsWLEC7du3x4YNG7BlyxaOcVMLluam+E+35gCA5QeuoQYjAxAREemVGo1zY8h45KairIJidPtsL3IVJfjhxSfQ28dF6pKIiIjU6PTIDQDs378fQ4cORcuWLdGyZUsMGzYMBw8erFGxJD37BuZ4rmszAMDS/dckroaIiKh2NA43a9euRd++fWFlZYWpU6di6tSpaNCgAfr06YN169bpokaqAy9184K5qQzH4zMQk3hP6nKIiIhqTOPTUr6+vnjllVfw1ltvqa1ftGgRVq5ciYsXL2q1QG3jaamqvbP+DNafuokBbd2w7IVOUpdDRESkotPTUtevX8fQoUMrrB82bBji4znSrSF7pWcLAMDOC6m4djtX4mqIiIhqRuNw4+HhgT179lRY//fff3NqAwPXytUWfX1dIASw6uB1qcshIiKqEY0H8ZsxYwamTp2K2NhYBAcHAwAOHz6M1atXY/HixVovkOrWqyHe+PtiOjaeSsZb/VrDxVZ3U2MQERHpgsbhZtKkSXBzc8PChQvx+++/Ayjrh/Pbb79h+PDhWi+Q6tYTzR3RybMhTiXcw+rDN/DuAB+pSyIiItIIx7mhCnadT8Ura07B1tIMR957CraW5o/fiIiISId02qH4xIkTOHbsWIX1x44d08qEmiS9vr6u8Ha2Rk5hCX49zlnUiYjIsGgcbiZPnoykpIpfeMnJyZg8ebJWiiJpmZjI8GpPbwDAfw/Fo6hEKXFFRERE1adxuLlw4QI6duxYYX1gYCAuXLiglaJIesMDG8PFVo7U7EJsjU2WuhwiIqJq0zjcyOVypKWlVVifkpICMzON+yeTnpKbmeKl7l4AgBUHrkOprFdds4iIyIBpHG6efvppREREICsrS7UuMzMT//d//4d+/fpptTiS1nNdm8FWboYr6bnYdyld6nKIiIiqReNw88UXXyApKQmenp7o3bs3evfuDS8vL6SmpmLhwoW6qJEkYmdpjueeLJtQc/l+DupHRESGQeNw06RJE5w9exYLFiyAn58fOnXqhMWLFyMuLo4jFBsh1YSaNzJwKoETahIRkf7jODf0WO9uOIPfT97E036uWBHeWepyiIioHtLpODcAsGbNGnTv3h2NGzdGQkICAODLL7/E1q1ba7I70nOv3L8sfPfFNFxN54SaRESk3zQON0uXLsX06dMxcOBA3Lt3D6WlpQCAhg0b4quvvtJ2faQHWrrYoJ+fK4QAVh5g3xsiItJvGoebb775BitXrsT777+vdul3586dERcXp9XiSH+8FtICALD5dDLSsgslroaIiKhqGoeb+Ph4BAYGVlgvl8uRl5enlaJI/3TydERnz4YoKlXih8M3pC6HiIioShqHGy8vL8TGxlZYHxUVBV9fX23URHrqtZCyvjc/H01AdmGxxNUQERFVTuMhhadPn47JkyejsLAQQggcP34cv/zyCyIjI7Fq1Spd1Eh64ikfF7R0scHV9Fz8ciwRr94PO0RERPpE43Dz8ssvo0GDBvjggw+Qn5+P5557Do0bN8bixYvx7LPP6qJG0hMmJjK80rMF3t1wFt8fjseL3ZpDbmYqdVlERERqajXOTX5+PnJzc+Hi4qLNmnSK49zUTlGJEj0W7EVatgILnmmHMZ05cCMREemeTse5KSgoQH5+PgDAysoKBQUF+Oqrr7Br166aVUsGxcLMBBPuT6i5fP81TqhJRER6R+NwM3z4cPz0008AyibM7NKlCxYuXIjhw4dj6dKlWi+Q9E9Yl7IJNa/dzsOefzmhJhER6ReNw01MTAx69OgBANiwYQPc3NyQkJCAn376CV9//bXWCyT9Y2tpjnFPegIoO3pDRESkTzQON/n5+bC1tQUA7Nq1CyNHjoSJiQmefPJJ1VQMZPxe6tYcFqYmOJlwDydvZEhdDhERkYrG4aZly5bYsmULkpKSsHPnTjz99NMAgPT0dHbQrUdc7CwxsmMTAMCy/ZySgYiI9IfG4eajjz7C22+/jebNm6Nr164ICgoCUHYUp7KRi8l4TezZAjIZ8PfFNFxNz5G6HCIiIgA1CDfPPPMMEhMTcfLkSURFRanW9+nTB19++aVWiyP95u1sg6f9XAEAKzihJhER6QmNww0AuLm5ITAwECYm/9u8S5cu8PHx0VphZBjKRynefDoZqVmcUJOIiKRXrXDz2muv4ebNm9Xa4W+//Yaff/65VkWR4ejYrCG6NHdEcanAD4fjpS6HiIioeuHG2dkZbdu2xaBBg7B06VKcOHECycnJuHv3Lq5evYo//vgD7777Lpo1a4Yvv/wSAQEB1XrwpUuXol27drCzs4OdnR2CgoKwY8eOKtuvXr0aMplMbbG0tKzeMyWdeTWkBQDg52OJnFCTiIgkV625pT7++GNMmTIFq1atwnfffYcLFy6o3W9ra4u+fftixYoVGDBgQLUfvGnTpvjss8/QqlUrCCHw448/Yvjw4Th9+jTatm1b6TZ2dna4dOmS6rZMJqv245Fu9G7jgtauNricloufjyZiUi9OqElERNKp0dxS9+7dQ2JiIgoKCtCoUSN4e3trLWQ4Ojri888/x4QJEyrct3r1akybNg2ZmZk13j/nltKNDadu4u31Z+BsK8ehmb05oSYREWmVTueWAoCGDRuiffv2ePLJJ9GyZUutBJvS0lL8+uuvyMvLU11eXpnc3Fx4enrCw8MDw4cPx/nz5x+5X4VCgezsbLWFtG9Y+8Zwt7fE7RwFtpxOlrocIiKqx2oUbrQpLi4ONjY2kMvleO2117B582b4+flV2rZNmzb4/vvvsXXrVqxduxZKpRLBwcGP7OwcGRkJe3t71eLhwVmsdUFtQs0D1zmhJhERSaZGp6W0qaioCImJicjKysKGDRuwatUq7N+/v8qA86Di4mL4+voiLCwMH3/8caVtFAoFFAqF6nZ2djY8PDx4WkoHchUlCIrcg5zCEix/oRP6t3WTuiQiIjISOj8tpU0WFhZo2bIlOnXqhMjISLRv3x6LFy+u1rbm5uYIDAzE1atXq2wjl8tVV2OVL6QbNnIzvHB/Qs1l+69B4txMRET1lOTh5mFKpVLtSMujlJaWIi4uDu7u7jquiqrrxW7NYWFmgtOJmTiZcE/qcoiIqB6SNNxERETgwIEDuHHjBuLi4hAREYF//vkH48aNAwCEh4cjIiJC1X7u3LnYtWsXrl+/jpiYGDz//PNISEjAyy+/LNVToIe42FpiVMemAIBl/1yTuBoiIqqPNA43aWlpeOGFF9C4cWOYmZnB1NRUbdFEeno6wsPD0aZNG/Tp0wcnTpzAzp070a9fPwBAYmIiUlJSVO3v3buHiRMnwtfXF4MGDUJ2djaOHDlSrf45VHcm9vCCTAbs+Tcdl9M4oSYREdUtjTsUDxw4EImJiZgyZQrc3d0rXAY+fPhwrRaobRznpm68tuYUos6n4plOTfHF6PZSl0NERAZOk+/vao1Q/KBDhw7h4MGD6NChQ03ro3rg1ZAWiDqfiq2xyZjxdGu42zeQuiQiIqonND4t5eHhwatg6LECmzVEV6+yCTW/P8QJNYmIqO5oHG6++uorvPfee7hx44YOyiFj8lpI2RxT644lIquAE2oSEVHd0Pi01NixY5Gfnw9vb29YWVnB3Nxc7f6MjAytFUeGrVcbZ7RxtcWltBz8fCwBr/dqKXVJRERUD2gcbr766isdlEHGSCaT4dWQFpj++xl8f+gGXurmBUtzTqhJRES6pXG4GT9+vC7qICM1tH1jfLHzEm5lFWLz6WSEdWkmdUlERGTkajSI37Vr1/DBBx8gLCwM6enpAIAdO3Y8doZuqn/MTU3w0v0JNVceuI5STqhJREQ6pnG42b9/PwICAnDs2DFs2rQJubm5AIAzZ85g1qxZWi+QDF9Yl2awb2CO63fysPtCqtTlEBGRkdM43Lz33nv45JNPsHv3blhYWKjWP/XUUzh69KhWiyPjYP3AhJpL91/nUAJERKRTGoebuLg4jBgxosJ6FxcX3LlzRytFkfEZH1w2oeaZpEwcj+cVdUREpDsahxsHBwe1+Z7KnT59Gk2aNNFKUWR8nG3leKbT/Qk193NCTSIi0h2Nw82zzz6LmTNnIjU1FTKZDEqlEocPH8bbb7+N8PBwXdRIRuKVHi0gkwH7Lt3Gv6nZUpdDRERGSuNwM2/ePPj4+MDDwwO5ubnw8/NDz549ERwcjA8++EAXNZKRaN7IGgP93QAAKw5cl7gaIiIyVhrPCl4uKSkJcXFxyM3NRWBgIFq1aoWCggI0aKDfEyRyVnBpnUnKxPAlh2FmIsOBd3ujsYN+f16IiEg/aPL9rfGRm6lTpwIom0Bz0KBBGDNmDFq1aoW8vDwMGjSoZhVTvdHewwFBLZxQohT4LyfUJCIiHdA43Pz5558VxrPJy8vDgAEDUFJSorXCyHi9GtICAPDL8URk5XNCTSIi0i6Nw82uXbuwcuVK1RxTOTk56NevH2QyGaKiorRdHxmhkNbO8HGzRX5RKdYeS5C6HCIiMjIahxtvb29ERUXh448/xtdff42nn34aFhYW2LFjB6ytrXVRIxmZ8gk1AeCHw/EoLC6VuCIiIjImNZpbql27dti+fTv+7//+D1ZWVgw2pLEh7RqjiUMD3MktwsaYm1KXQ0RERqRas4IHBgZCJpNVWC+Xy3Hr1i1069ZNtS4mJkZ71ZHRMjc1wYTuXpi7/QJWHriOZ59oBlOTip8xIiIiTVUr3ISGhuq4DKqPxj7hgcV7ruDG3XzsOp+KgQHuUpdERERGoMbj3BgqjnOjXxbtuoSv915F+6b22DK5W6VHCImIiHQ6zg2RNoUHN4fczARnbmbh6HVOqElERLWncbgpLS3FF198gS5dusDNzQ2Ojo5qC5EmGtnIMbpz2YSayw9wQk0iIqo9jcPNnDlzsGjRIowdOxZZWVmYPn06Ro4cCRMTE8yePVsHJZKxm9ijBUxkwD+XbuNiCifUJCKi2tE43Pz8889YuXIlZsyYATMzM4SFhWHVqlX46KOPcPToUV3USEbO08la1ZmYE2oSEVFtaRxuUlNTERAQAACwsbFBVlYWAGDIkCH4888/tVsd1Ruv9iwb1G9rbDL+OJOMrbHJiL52F6XKetXfnYiItKBal4I/qGnTpkhJSUGzZs3g7e2NXbt2oWPHjjhx4gTkcrkuaqR6oF1TB7RxtcGltFxM/SVWtd7d3hKzhvphgD8vEyciouqp9pGbFi1a4O7duxgxYgT27NkDAHjjjTfw4YcfolWrVggPD8dLL72ks0LJuEWdS8GltNwK61OzCjFpbQyizqVIUBURERmiao9zY2JigtTUVLi4uKitj46ORnR0NFq1aoWhQ4fqpEht4jg3+qdUKdB9/l6kZBVWer8MgJu9JQ7NfIqjGBMR1VOafH9rfFrqYUFBQQgKCqrtbqgeOx6fUWWwAQABICWrEMfjMxDk7VR3hRERkUHSKNzs3LkT9vb2j2wzbNiwWhVE9U96TtXBpibtiIioftMo3IwfP/6R98tkMpSWltaqIKp/XGwttdqOiIjqN40uBU9NTYVSqaxy0TTYLF26FO3atYOdnR3s7OwQFBSEHTt2PHKb9evXw8fHB5aWlggICMBff/2l0WOS/uni5Qh3e0s8qjeNqQywa1Drs6hERFQPVDvc6GJCw6ZNm+Kzzz7DqVOncPLkSTz11FMYPnw4zp8/X2n7I0eOICwsDBMmTMDp06cRGhqK0NBQnDt3Tuu1Ud0xNZFh1lA/AKgy4JQKYMyyaOy+kFZ3hRERkUGq9dVS2ubo6IjPP/8cEyZMqHDf2LFjkZeXh+3bt6vWPfnkk+jQoQOWLVtWrf3zain9FXUuBXO2XVDrXOxub4kZ/Vpj0+lkHLl2FzIZ8G5/H7wW0oIziBMR1SM6uVpq/PjxaNCgQa2Lq0ppaSnWr1+PvLy8Kq++io6OxvTp09XW9e/fH1u2bKlyvwqFAgqFQnU7O5tzF+mrAf7u6OfnhuPxGUjPKYSLrSW6eDnC1ESG4YFNMGfbeaw9moj5Uf/icloOIkcGwNLcVOqyiYhIz1Q73Pzwww86KSAuLg5BQUEoLCyEjY0NNm/eDD8/v0rbpqamwtXVVW2dq6srUlNTq9x/ZGQk5syZo9WaSXdMTWSVXu5tbmqCT0ID0MbVFrO3XcDm08mIv5OHFeGd2NGYiIjUaDy3lLa1adMGsbGxOHbsGCZNmoTx48fjwoULWtt/REQEsrKyVEtSUpLW9k1174Wg5vjppS6wb2CO2KRMDP/2MM4lZ0ldFhER6RHJw42FhQVatmyJTp06ITIyEu3bt8fixYsrbevm5oa0NPUOpWlpaXBzc6ty/3K5XHU1VvlChq1by0bYMrkbWjhbIyWrEM8sO4K/4jg9AxERlZE83DxMqVSq9ZF5UFBQkGpeq3K7d+/mCMn1kFcja2x+vRt6tnZGYbESr/8cg8V/X0E1+8cTEZERq3G4uXr1Knbu3ImCggIAqNGXSkREBA4cOIAbN24gLi4OERER+OeffzBu3DgAQHh4OCIiIlTt33zzTURFRWHhwoX4999/MXv2bJw8eRJTpkyp6dMgA2bfwBzfj++MCd29AABf/n0ZU345jYIiDiRJRFSfaRxu7t69i759+6J169YYNGgQUlLKTgdMmDABM2bM0Ghf6enpCA8PR5s2bdCnTx+cOHECO3fuRL9+/QAAiYmJqv0DQHBwMNatW4cVK1agffv22LBhA7Zs2QJ/f39NnwYZCTNTE3w4xA/zRwXA3FSGP8+mYPTyI0jJKpC6NCIikki1x7kpFx4ejvT0dKxatQq+vr44c+YMWrRogZ07d2L69OlVDsCnLzjOjfE6dv0uJv0cg4y8IjjbyrHihU4IbNZQ6rKIiEgLNPn+1vjIza5duzB//nw0bdpUbX2rVq2QkJCg6e6ItKZrCydsndwNbVxtcTtHgbErjmJrbLLUZRERUR3TONzk5eXBysqqwvqMjAzI5XKtFEVUUx6OVtj4ejD6+rqgqESJN3+Nxec7/4VSyY7GRET1hcbhpkePHvjpp59Ut2UyGZRKJRYsWIDevXtrtTiimrCRm2H5C50xqZc3AGDJvmt4de0p5ClKJK6MiIjqgsZ9bs6dO4c+ffqgY8eO2Lt3L4YNG4bz588jIyMDhw8fhre3t65q1Qr2ualfNsXcxHsb41BUqoSPmy1Wje+Mpg0rHnkkIiL9ptM+N/7+/rh8+TK6d++O4cOHIy8vDyNHjsTp06f1PthQ/TOyY1P8+uqTaGQjx7+pORj+7WGcuJEhdVlERKRDGh+5MXQ8clM/3coswMSfTuL8rWyYm8rw6YgAjOnsIXVZRERUTZp8f9co3BQWFuLs2bNIT0+HUqlUu2/YsGGa7q5OMdzUX/lFJZjx+xnsOFc20erL3b0QMcgXpiYyiSsjIqLH0Wm4iYqKQnh4OO7cuVNxZzIZSkv1e3RYhpv6TakU+GrPFXy95woAoFcbZ3wdFgg7S3OJKyMiokfRaZ+bN954A6NHj0ZKSgqUSqXaou/BhsjERIbp/Vrjm7BAyM1M8M+l2xj53REk3M2TujQiItISjcNNWloapk+fDldXV13UQ1QnhrZvjPWvBcHVTo6r6bkYvuQwjlyreDSSiIgMj8bh5plnnsE///yjg1KI6la7pg74Y0p3tG9qj8z8YoT/9zh+PsZRtomIDJ3GfW7y8/MxevRoODs7IyAgAObm6n0Vpk6dqtUCtY19buhhhcWlmLnxLLbG3gIAjA/yxIdD/GBmqnH2JyIiHdFph+L//ve/eO2112BpaQknJyfIZP+70kQmk+H69es1q7qOMNxQZYQQ+O6fa/h85yUAQPeWjbDkuY6wt2JHYyIifaDTcOPm5oapU6fivffeg4mJ4f1ly3BDj7LzfCre+i0W+UWl8GpkjZXhndHSxUbqsoiI6j2dXi1VVFSEsWPHGmSwIXqc/m3dsOG1YDRxaID4O3kY8d1h7L98W+qyiIhIAxonlPHjx+O3337TRS1EesGvsR22TumGzp4NkVNYgv/8cBzfH4pH+UHOUqVA9LW72BqbjOhrd1HKGceJiPSKmaYblJaWYsGCBdi5cyfatWtXoUPxokWLtFYckVQa2cjx88SueH/zOWw4dRNzt1/A5bQcdGvZCPP+uoiUrEJVW3d7S8wa6ocB/u4SVkxEROU07nPTu3fvqncmk2Hv3r21LkqX2OeGNCGEwKqD8Zi34yKq+kkp71K/9PmODDhERDqi87mlDBnDDdXEngtpePmnk6jqh0UGwM3eEodmPsW5qoiIdECnHYqJ6iMruVmVwQYABICUrEIcj8+oq5KIiKgK1epzM3LkSKxevRp2dnYYOXLkI9tu2rRJK4UR6ZP0nMLHN9KgHRER6U61wo29vb1qsD57e3udFkSkj1xsLbXajoiIdKda4eaHH37A3Llz8fbbb+OHH37QdU1EeqeLlyPc7S2RmlVY6emp8j43Xbwc67o0IiJ6SLX73MyZMwe5ubm6rIVIb5mayDBrqB+A/10d9bBZQ/3YmZiISA9UO9zUs4uqiCoY4O+Opc93hJt9xVNPT7Zw4mXgRER6QqNB/B6cJJOoPhrg745+fm44Hp+B9JxCZOYXYdYfFxB9/S4OXbmD7q0aSV0iEVG9p1G4ad269WMDTkYGL4Ul42ZqIkOQt5Pq9rXbefgpOgERm89i17QQNLAwlbA6IiLSKNzMmTOHV0sRPeTdAT7YfSENSRkFWLT7Et4f7Cd1SURE9Vq1Ryg2MTFBamoqXFxcdF2TTnGEYtKFvf+m4aXVJ2EiAza/3g3tPRykLomIyKjoZIRi9rchqtpTPq4Y1r4xlAKYufEsikuVUpdERFRv8WopIi2ZNdQPDa3M8W9qDlYcuC51OURE9Va1w41SqTT4U1JEuuRkI8eHQ8r62yzecwXXbnNcKCIiKXDiTCItGhHYBD1bO6OoRImIjXFQKnnEk4iorkkabiIjI/HEE0/A1tYWLi4uCA0NxaVLlx65zerVqyGTydQWS0vO50P6QSaT4dNQf1hZmOL4jQysO54odUlERPWOpOFm//79mDx5Mo4ePYrdu3ejuLgYTz/9NPLy8h65nZ2dHVJSUlRLQkJCHVVM9HgejlZ4++k2AIDPdvyL1CzOFE5EVJc0GudG26KiotRur169Gi4uLjh16hR69uxZ5XYymQxubm66Lo+oxsYHN8cfZ24hNikTH2w5h5XhnXjFIRFRHdGrPjdZWVkAAEfHR8+snJubC09PT3h4eGD48OE4f/58lW0VCgWys7PVFiJdMzWRYf6odjA3leHvi2n4Ky5V6pKIiOoNvQk3SqUS06ZNQ7du3eDv719luzZt2uD777/H1q1bsXbtWiiVSgQHB+PmzZuVto+MjIS9vb1q8fDw0NVTIFLTxs0Wk3q1BADM+uMcMvOLJK6IiKh+qPYIxbo2adIk7NixA4cOHULTpk2rvV1xcTF8fX0RFhaGjz/+uML9CoUCCoVCdTs7OxseHh4coZjqhKKkFIO/PoSr6bkY3akpPh/dXuqSiIgMkk5GKNalKVOmYPv27di3b59GwQYAzM3NERgYiKtXr1Z6v1wuh52dndpCVFfkZqaYPyoAMhmw/tRNHLpyR+qSiIiMnqThRgiBKVOmYPPmzdi7dy+8vLw03kdpaSni4uLg7u6ugwqJaq+TpyPCn/QEAERsPov8ohKJKyIiMm6ShpvJkydj7dq1WLduHWxtbZGamorU1FQUFBSo2oSHhyMiIkJ1e+7cudi1axeuX7+OmJgYPP/880hISMDLL78sxVMgqpZ3Bvigsb0lkjIK8OXuy1KXQ0Rk1CQNN0uXLkVWVhZ69eoFd3d31fLbb7+p2iQmJiIlJUV1+969e5g4cSJ8fX0xaNAgZGdn48iRI/Dz85PiKRBVi43cDJ+MKOso/99D8TiTlCltQURERkxvOhTXFU06JBFp29RfTuOPM7fg42aLbW90h7mpXnR7IyLSewbXoZiovuDM4UREusdwQ1SHnGzk+GgoZw4nItIlhhuiOhbagTOHExHpEsMNUR2TyWSYN4IzhxMR6QrDDZEEmjbkzOFERLrCcEMkkfHBzdHBwwG5ihJ8sOUc6tmFi0REOsNwQyQRUxMZFjzDmcOJiLSN4YZIQq1dOXM4EZG2MdwQSWxyb2+0dLHBndwifPLnRanLISIyeAw3RBJ7cObwDZw5nIio1hhuiPQAZw4nItIehhsiPcGZw4mItIPhhkhP2MjN8OmIAACcOZyIqDYYboj0SG8fFwzv0BhKAczceBbFpUqpSyIiMjgMN0R65qMh9WPm8FKlQPS1u9gam4zoa3dRyjm2iEhLzKQugIjUlc8c/tZvZ7B4zxUM8HeDt7ON1GVpVdS5FMzZdgEpD0w74W5viVlD/TDA313CyojIGPDIDZEeCu3QBCFGOnN41LkUTFoboxZsACA1qxCT1sYg6lyKRJURkbFguCHSQzKZDJ8a4czhpUqBOdsuoLKoVr5uzrYLPEVFRLXCcEOkp5o2tMI7/Y1r5vDj8RkVjtg8SABIySrE8fiMuiuKiIwOww2RHgsPMq6Zw9NzqhfQqtuOiKgyDDdEeuzhmcP/jDPc/ihX0nLwy7HqnV5zsbXUcTVEZMwYboj0XGtXW7x+f+bw2X+cN7iZw6/fzsW0X0/j6a8O4OhjTjfJUHbVVBcvx7opjoiMEsMNkQF43QBnDk+8m4+3159Bvy8PYEvsLQgB9G/rig+G+EKGsiDzMAFg1lA/mJpUdi8RUfVwnBsiA1A2c3g7PLPsCDacuonQDk3QvVUjqcuqVHJmAb7dewXrT95Eyf2rnvr4uOCtfq3h38QeANDUoUGFcW4AwNxUZnRj+hBR3ZMJQ++hqKHs7GzY29sjKysLdnZ2UpdDpJFZW8/hx+gEeDg2wM5pPWFloT9/n6RmFWLJvqv49UQiikvLfq30bO2M6f1ao4OHQ4X2pUqB4/EZSM8phLONHEv3X8PBK3fQxtUWW6d0g6W5aR0/AyLSZ5p8fzPcEBmQXEUJnl60H7eyCvFydy98MMRP6pKQnlOIZf9cx9pjCSgqKZsLK9jbCdP7tUbn5tXvO3M7R4GBiw/iTq4Czz/ZDJ+EBuiqZCIyQJp8f7PPDZEBsZGb4dORZV/63x+WdubwjLwiRP51ET0X7MP3h+NRVKLEE80b4peJT2LdxCc1CjYA4Gwrx6Ix7QEAa48mcqRiIqoxhhsiA9O7jbQzh2fmF+Hznf+ix/y9WH7gOgqLlejg4YA1E7rg91eDEOTtVON992ztjFdDWgAA3t1wFjfv5WurbCKqRxhuiAyQFDOHZxcW48vdl9Fj/j4s2XcNeUWl8G9ih+9f7IzNrwejRytnyGS1v8rp7afboIOHA7ILSzDt11iU1HF4IyLDx3BDZIDKZw4HgMV7ruDa7VydPVauogRL9l1Fj/n7sHjPFeQoSuDjZovlL3TCtind8ZSPq1ZCTTlzUxN8ExYIW7kZTibcw+I9V7S2byKqHxhuiAxUaIcm6NVGdzOHFxSVYvn+a+i5YB8+33kJWQXFaOligyXPdcRfU3ugf1s3rYaaB3k4WmHe/b5F3+67iiPX7ujkcYjIODHcEBkomUyGT0K1P3N4YXEp/nsoHj0W7EPkjn+RkVcEr0bWWPxsB+yc1hOD27nDpA4G2RvavjHGdvaAEMBbv8Xibq5C549JRMaB4YbIgD08c3hKVkGN96UoKcWa6BsI+XwfPt5+AXdyFfBwbIDPn2mH3W/1xPAOTep85OBZw/zQ0sUGadkKvLPhrMFPHEpEdUPScBMZGYknnngCtra2cHFxQWhoKC5duvTY7davXw8fHx9YWloiICAAf/31Vx1US6SfwoOaI7BZ2czhH9Zg5vDiUiV+OZ6Ip77Yjw+3nkdatgKN7S0ROTIAe2f0wujOHjAzleZXhZWFGb59LhAWZibY+286vj98Q5I6iMiwSBpu9u/fj8mTJ+Po0aPYvXs3iouL8fTTTyMvL6/KbY4cOYKwsDBMmDABp0+fRmhoKEJDQ3Hu3Lk6rJxIf5iayDB/VPnM4enVnjm8pFSJ9SeT8NTCfxCxKQ7JmQVwtZPj4+Ftse+dXgjr0gzmEoWaB/m42eHDwb4AgM92XMS55CyJKyIifadXIxTfvn0bLi4u2L9/P3r27Flpm7FjxyIvLw/bt29XrXvyySfRoUMHLFu27LGPwRGKyVh9ufsyFu+5gkY2Ftg5rScup+UiPacQLrZls2yXn1IqVQpsO3MLi/dcQfydsj8kGtnI8XovbzzXtZleTnsghMBra09h5/k0eDWyxrY3usNGrj9TTxCR7mny/a1Xvx2yssr+InN0rHpk0+joaEyfPl1tXf/+/bFly5ZK2ysUCigU/+uImJ2dXftCifTQ67298VdcCq6k56L7/H0oKC5V3edub4kPB/tBAPjq78u4kl526XhDK3O8FuKNF4I89WqeqofJZGVHp+JuHkT8nTx8tOUcFo3tIHVZRKSnpD/mfJ9SqcS0adPQrVs3+Pv7V9kuNTUVrq6uautcXV2RmppaafvIyEjY29urFg8PD63WTaQv5GamCA1sAgBqwQYAUrIK8fq6GExeF4Mr6bmwb2COd/q3wcGZT+HVEG+9DjblHKwssDgsECYyYNPpZGyKuSl1SUSkp/Qm3EyePBnnzp3Dr7/+qtX9RkREICsrS7UkJSVpdf9E+qJUKbD2aMIj28gATO3TEgdn9sbk3i0N7tTOE80dMa1vawDAB1vOqU6rERE9SC/CzZQpU7B9+3bs27cPTZs2fWRbNzc3pKWlqa1LS0uDm5tbpe3lcjns7OzUFiJjdDw+AylZhY9sIwAEtWgEO0vzuilKByb3boknWzgiv6gUb/wSA0VJ6eM3IqJ6RdJwI4TAlClTsHnzZuzduxdeXl6P3SYoKAh79uxRW7d7924EBQXpqkwig5Ce8+hgo2k7fWVqIsNXYwPR0Moc55KzsSDq8cNHEFH9Imm4mTx5MtauXYt169bB1tYWqampSE1NRUHB/wYiCw8PR0REhOr2m2++iaioKCxcuBD//vsvZs+ejZMnT2LKlClSPAUiveFia6nVdvrMzd4SX4xuDwD476F47P037TFbEFF9Imm4Wbp0KbKystCrVy+4u7urlt9++03VJjExESkp/xu3Izg4GOvWrcOKFSvQvn17bNiwAVu2bHlkJ2Si+qCLlyPc7S1R1RjCMpRdNdXFq+qrEQ1JH19X/KdbcwDA2+vPIi3bsI9IEZH26NU4N3WB49yQMYs6l4JJa2MAlPWvKVceeJY+3xED/N3rvC5dUZSUYuR3R3D+VjaCWjhh7ctd63yKCCKqG5p8f+tFh2Ii0o4B/u5Y+nxHuNmrn3pys7c0umADlF3+/k1YIKwsTBF9/S6W/nNV6pKISA/wyA2RESpVChyPz6h0hGJjtPHUTcxYfwamJjL89sqT6NzcOE69EdH/8MgNUT1naiJDkLcThndogiBvJ6MONgAwqlNTjAhsglKlwJu/xiIrv1jqkohIQgw3RGQUPg71R3MnKyRnFmDmxrMaz45ORMaD4YaIjIKN3AzfhHWEuakMUedT8fOxRKlLIiKJMNwQkdEIaGqPmQN8AABzt1/Av6mcKJeoPmK4ISKjMqG7F3q3cUZRiRJT1p1GQRGnZyCqbxhuiMioyGQyfDG6PVxs5bianou5289LXRIR1TGGGyIyOk42cnw1tgNkMuCX40n482zK4zciIqPBcENERim4ZSNM7tUSAPDeprNIysiXuCIiqisMN0RktKb1bYVOng2RU1iCN345jeJSpdQlEVEdYLghIqNlZmqCxc92gJ2lGWKTMrFo92WpSyKiOsBwQ0RGrWlDK8wf1Q4AsGz/NRy6ckfiiohI1xhuiMjoDQxwx3Ndm0EI4K3fY3E7RyF1SURGqVQpEH3tLrbGJiP62l2UKqUZKdxMkkclIqpjHw3xw6kb93ApLQcz1p/B6hefgImRz7lFVJeizqVgzrYLSMkqVK1zt7fErKF+GODvXqe18MgNEdULluam+Oa5QFiam+DA5dtYdei61CURGY2ocymYtDZGLdgAQGpWISatjUHUubodjoHhhojqjdautvhoSFsAwIKoSziTlCltQURGoFQpMHvbBVR2Aqp83ZxtF+r0FBVPSxFRvRLWxQOHr97Bn3EpeOOX0/hzanfYWppLXRaR3hNCIC1bgRt383DjTh5u3M3HjTt5OH8rC6kPHbFR2w5ASlYhjsdnIMjbqU5qZbghonpFJpNh3sgAxCZlIjEjH+9vPofFz3aATMb+N6TfSpUCx+MzkJ5TCBdbS3TxcoSplvuNVRVgbtzNQ8LdfBQU13yutvScqgOQtjHcEFG9Y9/AHF+HBWLM8mj8ceYWurdqhDGdPaQui6hK2uysK4RAeo4C8Xc0DzCmJjI0bdgAzZ2s0dzJCs0bWaOwqBTzd1567OO62FpqVGdtMNwQUb3UybMhpvdrjc93XsKsrefRsVlDtHSxkbosogrKO+s+3GOlvLPu0uc7Vgg4DwaYhLt5iL9TuwDT3MkazRtZo2nDBjA3Ve+uW6oU+OloAlKzCivtdyMD4GZfdqSprjDcEFG9NSnEG0eu3cHhq3fxxi+nsfn1YFiam0pdFpFKqVJgzmM6676/+Rzu5Rch4W7B/SBT/QDj6WQNr2oEmEcxNZFh1lA/TFobA9kDdQFlwQYAZg310/optEeRCSGkGWFHItnZ2bC3t0dWVhbs7OykLoeIJJaeXYiBiw/ibl4RXgxujtnD2kpdEpFK9LW7CFt5tEbbajPAVIeux7nR5Pub4YaI6r1/LqXjxR9OAABWvNAJT7d1k7giqm9KlQI37+Xj2u1cXEvPw/U7Zf9eTMlCjuLxnXh93GzR1cuxLMg0KgswTRwawMKsbkd80WWnZ02+v3laiojqvV5tXDCxhxdWHozHuxvPIqCpPdztG0hdFhmh7MJiXL+dh2vpuaoAc/1OLm7cyUdRLWatnzW0bZ1dZv0opiYyvaiD4YaICMA7/X1wLD4DZ29m4c1fY/HLxCfrtI8ASUubRxxKlQK3Mgtw9XZuWZC5nXs/zOQ9cl4zuZkJvBpZw9vFBt73//V0tMara08iPVuhN511DQHDDRERAAszE3z9bCCGfHMIx+Mz8M3eK3jjqVY6H1eEpFfTviK5ihJcv52Law+EmOu383D9Th6KSqo+CuNiK4e3sw1aOFvD29kG3i42aHH/NFJl853NGdZWrzrrGgL2uSEiesDW2GS8+WssZAAaWlsgI69IdZ9UkwCS7lR1mXV5VFjyXEe087DHtdt5qiBTfiopLbvqozAWpmVHYf4XYKzRolFZoKnJiNj6NCmlVNih+BEYbojoccJWHEX09bsV1pd/4VU2rggZnlKlQPf5eytM9qiJRjby/wUY1b82aNKwgdaPptTFCMX6jB2KiYhqqFQpcP1ObqX3CZQFnDnbLqCfn1u9+mKpDSm+lAuLS3EnV4E7uUW4k6O4//+y27dzFLidq0BSRn61go2pCeDV6H/hpcX9INPC2Qb2DepuXjJ96axrCBhuiIgecDw+45GnG8onAfzteCJCfFzgZG0h6cB/+v7XvDZPpxQUlQWW27mK+4Gl6IHQosCdnLLbt3MUyFGUaO05fPFMe4zo2FRr+yPdY7ghInpAdSf3+78t51T/t7YwhaONBZys5XCytoCjtQUcbSzQyFqu/n8bC62GIX3vh1GdaQN6tnbGnZyissByP5g8HFbKj7jkahhYzE1laGQjh7OtHI1s5GhkY3H/Xzka2cqRnl2IT/68+Nj9uHFYAIPDcENE9IDqTu7n0MAcuYoSlCgF8opKkZdRgKSMgmpta2VhCicbCzg+EIac7gcfR2v5A/8vC0wNLCqGoZrMN1RTQgiUKAUUJUooikvL/i1RQlFSCkWxEkWlSiiK79++v76gqBSf7fj3kdMGVFb/41iYmcD5fjhxfjCs2FigkSrEyOFsI4ddA7NHzvZeqhT476F4vZoTibRD0nBz4MABfP755zh16hRSUlKwefNmhIaGVtn+n3/+Qe/evSusT0lJgZsbRxQlotrr4uUId3vLx37hHZr5FExkQHZhCTLyinA3V4G7eUXIuL/cyVU88P8iZOSV3S4uFcgvKkW+hmGoLOhYwMlGjoZW5og6l/rI4DBzYxyS7hWgWBU8/hc+isrDSXGp2npVULkfWh68TxeXnpTv0tLc5KEjLPeDywO3y8OLrfzRgUUT+jgnEmmHpOEmLy8P7du3x0svvYSRI0dWe7tLly6p9ZR2cXHRRXlEVA9p+oVn38Ac9g3M4dXI+rH7FkIgR1GCu/fDTtm/RbibV/S/dar/ly1FpcqyMFRUgJv3qheGACCroBifVuOUS01YmJlAbmoCubkJ5GamkJuZlK0zL/u/3MwE9/KKcO5W9mP3teCZdhjdqanWAoumBvi7Y+nzHSuc3nPTo9N7pDlJw83AgQMxcOBAjbdzcXGBg4OD9gsiIoLuvvBkMhnsLM1hZ6lZGMrILVIdFbqbq8Chq3ew/WzKY7fv2MwB3s42aiFEbmYKubkJLB4KJ/KHwomF2QP3PRhiTE0qHWjuYdWd8NGjoZVkwabcAH939PNz0+uO2aQZg+xz06FDBygUCvj7+2P27Nno1q1blW0VCgUUiv9d+ZCd/fi/JIiI9OEL78Ew1PyBMOTpZF2tcPNOfx/JLh2u7uk9fenPwsusjUvdThdaS+7u7li2bBk2btyIjRs3wsPDA7169UJMTEyV20RGRsLe3l61eHh41GHFRGTIyr/whndogiBvJ735S748OFRVjQxlV01JGRzKT++V1/Mg9mchXdObEYplMtljOxRXJiQkBM2aNcOaNWsqvb+yIzceHh4coZiIDFr51VJA5f2C9GUUZX2/XJ0MR70aobhLly44dOhQlffL5XLI5fI6rIiISPcMpSOsPpzeo/rH4MNNbGws3N3144eYiKguGUpwYH8WqmuShpvc3FxcvXpVdTs+Ph6xsbFwdHREs2bNEBERgeTkZPz0008AgK+++gpeXl5o27YtCgsLsWrVKuzduxe7du2S6ikQEUmKwYGoIknDzcmTJ9UG5Zs+fToAYPz48Vi9ejVSUlKQmJiour+oqAgzZsxAcnIyrKys0K5dO/z999+VDuxHRERE9ZPedCiuK5p0SCIiIiL9oMn3t0FdCk5ERET0OAw3REREZFQYboiIiMioMNwQERGRUWG4ISIiIqPCcENERERGheGGiIiIjIrBT7+gqfJhfbKzsyWuhIiIiKqr/Hu7OsPz1btwk5OTAwDw8PCQuBIiIiLSVE5ODuzt7R/Zpt6NUKxUKnHr1i3Y2tpCJtOvyeXqQnZ2Njw8PJCUlMQRmmuBr6N28HXUDr6O2sHXUTt09ToKIZCTk4PGjRvDxOTRvWrq3ZEbExMTNG3aVOoyJGdnZ8cfXi3g66gdfB21g6+jdvB11A5dvI6PO2JTjh2KiYiIyKgw3BAREZFRYbipZ+RyOWbNmgW5XC51KQaNr6N28HXUDr6O2sHXUTv04XWsdx2KiYiIyLjxyA0REREZFYYbIiIiMioMN0RERGRUGG6IiIjIqDDc1AORkZF44oknYGtrCxcXF4SGhuLSpUtSl2XwPvvsM8hkMkybNk3qUgxOcnIynn/+eTg5OaFBgwYICAjAyZMnpS7LoJSWluLDDz+El5cXGjRoAG9vb3z88cfVmnenPjtw4ACGDh2Kxo0bQyaTYcuWLWr3CyHw0Ucfwd3dHQ0aNEDfvn1x5coVaYrVY496HYuLizFz5kwEBATA2toajRs3Rnh4OG7dulVn9THc1AP79+/H5MmTcfToUezevRvFxcV4+umnkZeXJ3VpBuvEiRNYvnw52rVrJ3UpBufevXvo1q0bzM3NsWPHDly4cAELFy5Ew4YNpS7NoMyfPx9Lly7Ft99+i4sXL2L+/PlYsGABvvnmG6lL02t5eXlo3749lixZUun9CxYswNdff41ly5bh2LFjsLa2Rv/+/VFYWFjHleq3R72O+fn5iImJwYcffoiYmBhs2rQJly5dwrBhw+quQEH1Tnp6ugAg9u/fL3UpBiknJ0e0atVK7N69W4SEhIg333xT6pIMysyZM0X37t2lLsPgDR48WLz00ktq60aOHCnGjRsnUUWGB4DYvHmz6rZSqRRubm7i888/V63LzMwUcrlc/PLLLxJUaBgefh0rc/z4cQFAJCQk1ElNPHJTD2VlZQEAHB0dJa7EME2ePBmDBw9G3759pS7FIP3xxx/o3LkzRo8eDRcXFwQGBmLlypVSl2VwgoODsWfPHly+fBkAcObMGRw6dAgDBw6UuDLDFR8fj9TUVLWfbXt7e3Tt2hXR0dESVmb4srKyIJPJ4ODgUCePV+8mzqzvlEolpk2bhm7dusHf31/qcgzOr7/+ipiYGJw4cULqUgzW9evXsXTpUkyfPh3/93//hxMnTmDq1KmwsLDA+PHjpS7PYLz33nvIzs6Gj48PTE1NUVpaik8//RTjxo2TujSDlZqaCgBwdXVVW+/q6qq6jzRXWFiImTNnIiwsrM4mJGW4qWcmT56Mc+fO4dChQ1KXYnCSkpLw5ptvYvfu3bC0tJS6HIOlVCrRuXNnzJs3DwAQGBiIc+fOYdmyZQw3Gvj999/x888/Y926dWjbti1iY2Mxbdo0NG7cmK8j6Y3i4mKMGTMGQggsXbq0zh6Xp6XqkSlTpmD79u3Yt28fmjZtKnU5BufUqVNIT09Hx44dYWZmBjMzM+zfvx9ff/01zMzMUFpaKnWJBsHd3R1+fn5q63x9fZGYmChRRYbpnXfewXvvvYdnn30WAQEBeOGFF/DWW28hMjJS6tIMlpubGwAgLS1NbX1aWprqPqq+8mCTkJCA3bt319lRG4Dhpl4QQmDKlCnYvHkz9u7dCy8vL6lLMkh9+vRBXFwcYmNjVUvnzp0xbtw4xMbGwtTUVOoSDUK3bt0qDEVw+fJleHp6SlSRYcrPz4eJifqvcFNTUyiVSokqMnxeXl5wc3PDnj17VOuys7Nx7NgxBAUFSViZ4SkPNleuXMHff/8NJyenOn18npaqByZPnox169Zh69atsLW1VZ07tre3R4MGDSSuznDY2tpW6KdkbW0NJycn9l/SwFtvvYXg4GDMmzcPY8aMwfHjx7FixQqsWLFC6tIMytChQ/Hpp5+iWbNmaNu2LU6fPo1FixbhpZdekro0vZabm4urV6+qbsfHxyM2NhaOjo5o1qwZpk2bhk8++QStWrWCl5cXPvzwQzRu3BihoaHSFa2HHvU6uru745lnnkFMTAy2b9+O0tJS1feOo6MjLCwsdF9gnVyTRZICUOnyww8/SF2aweOl4DWzbds24e/vL+RyufDx8RErVqyQuiSDk52dLd58803RrFkzYWlpKVq0aCHef/99oVAopC5Nr+3bt6/S34fjx48XQpRdDv7hhx8KV1dXIZfLRZ8+fcSlS5ekLVoPPep1jI+Pr/J7Z9++fXVSn0wIDmdJRERExoN9boiIiMioMNwQERGRUWG4ISIiIqPCcENERERGheGGiIiIjArDDRERERkVhhsiIiIyKgw3RGSQmjdvjq+++qra7WfPno0OHTrorB4i0h+cfoGIDNKJEydgbW0tdRlEpIcYbojIIDk7O0tdAhHpKZ6WIiLJ9OrVC1OnTsW7774LR0dHuLm5Yfbs2dXa9uHTUomJiRg+fDhsbGxgZ2eHMWPGIC0trcJ2y5cvh4eHB6ysrDBmzBhkZWWp7vvnn3/QpUsXWFtbw8HBAd26dUNCQkJtnyYR1TGGGyKS1I8//ghra2scO3YMCxYswNy5c7F7926N9qFUKjF8+HBkZGRg//792L17N65fv46xY8eqtbt69Sp+//13bNu2DVFRUTh9+jRef/11AEBJSQlCQ0MREhKCs2fPIjo6Gq+88gpkMpnWnisR1Q2eliIiSbVr1w6zZs0CALRq1Qrffvst9uzZg379+lV7H3v27EFcXBzi4+Ph4eEBAPjpp5/Qtm1bnDhxAk888QQAoLCwED/99BOaNGkCAPjmm28wePBgLFy4EBYWFsjKysKQIUPg7e0NAPD19dXmUyWiOsIjN0QkqXbt2qnddnd3R3p6ukb7uHjxIjw8PFTBBgD8/Pzg4OCAixcvqtY1a9ZMFWwAICgoCEqlEpcuXYKjoyNefPFF9O/fH0OHDsXixYuRkpJSw2dFRFJiuCEiSZmbm6vdlslkUCqVktTyww8/IDo6GsHBwfjtt9/QunVrHD16VJJaiKjmGG6IyOD5+voiKSkJSUlJqnUXLlxAZmYm/Pz8VOsSExNx69Yt1e2jR4/CxMQEbdq0Ua0LDAxEREQEjhw5An9/f6xbt65ungQRaQ3DDREZvL59+yIgIADjxo1DTEwMjh8/jvDwcISEhKBz586qdpaWlhg/fjzOnDmDgwcPYurUqRgzZgzc3NwQHx+PiIgIREdHIyEhAbt27cKVK1fY74bIALFDMREZPJlMhq1bt+KNN95Az549YWJiggEDBuCbb75Ra9eyZUuMHDkSgwYNQkZGBoYMGYLvvvsOAGBlZYV///0XP/74I+7evQt3d3dMnjwZr776qhRPiYhqQSaEEFIXQUSkKXd3d3z88cd4+eWXpS6FiPQMj9wQkUHJz8/H4cOHkZaWhrZt20pdDhHpIYYbItI7P//8c5Wng4QQsLS0xLRp0xAUFFTHlRGRIeBpKSLSOzk5OZVOnQCUXTru6elZxxURkSFhuCEiIiKjwkvBiYiIyKgw3BAREZFRYbghIiIio8JwQ0REREaF4YaIiIiMCsMNERERGRWGGyIiIjIqDDdERERkVP4f29saZFCruxoAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from time import time\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "n_jobs_values = np.arange(1,13)\n",
+    "performance_times_avg = []\n",
+    "\n",
+    "for n_jobs in n_jobs_values:\n",
+    "    times = []\n",
+    "    for _ in range(5): \n",
+    "        start_time = time()\n",
+    "\n",
+    "        gwr_selector = Sel_BW(b_coords, b_y, b_X,n_jobs=n_jobs) #n_jobs\n",
+    "        gwr_bw = gwr_selector.search()\n",
+    "        gwr_results = GWR(b_coords, b_y, b_X, gwr_bw,n_jobs=n_jobs).fit() #n_jobs\n",
+    "\n",
+    "        end_time = time()\n",
+    "        times.append(end_time - start_time)\n",
+    "    average_time = sum(times) / len(times)\n",
+    "    performance_times_avg.append(average_time)\n",
+    "\n",
+    "# Plotting the results\n",
+    "plt.plot(n_jobs_values, performance_times_avg,marker='o')\n",
+    "plt.xlabel('n_jobs')\n",
+    "plt.ylabel('Time Taken (seconds)')\n",
+    "plt.title('GWR Performance with Different n_jobs Values')"
    ]
   },
   {
@@ -184,37 +267,1818 @@
    "metadata": {},
    "outputs": [
     {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "26f25e3470be4f14bfffdcc2fcdf213b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[ 191. 1279.   79. 2200.]\n",
-      "CPU times: user 5.08 s, sys: 388 ms, total: 5.46 s\n",
-      "Wall time: 2min 2s\n"
+      "[ 191. 1279.   79. 2200.]\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c6983fdda7194518a3ff89516812a27a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/12 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 27.2 s, sys: 6.47 s, total: 33.7 s\n",
+      "Wall time: 34.2 s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "mgwr_selector = Sel_BW(b_coords, b_y, b_X, multi=True)\n",
-    "mgwr_bw = mgwr_selector.search(pool=pool) #add pool to Sel_BW.search\n",
+    "mgwr_selector = Sel_BW(b_coords, b_y, b_X, multi=True,n_jobs=n_jobs) #add n_jobs to MGWR()\n",
+    "mgwr_bw = mgwr_selector.search()\n",
     "print(mgwr_bw)\n",
-    "mgwr_results = MGWR(b_coords, b_y, b_X, selector=mgwr_selector).fit(pool=pool) #add pool to MGWR.fit"
+    "mgwr_results = MGWR(b_coords, b_y, b_X, selector=mgwr_selector,n_jobs=n_jobs).fit() #add n_jobs to MGWR()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "09794a3fe83948358d642820b053d201",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ceff7821a6d74ea2935fc693f226d6af",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c033a46d86844baf94a6cee9ec0d2c54",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3eef50a0a3814437b1bc1c22cfd67f80",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d3f70a5fefa942febbc55a6e41d06ca3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f73e0336fb7049e0bcf7659cd8be2cd0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d67df8d62524e109aa614050a285bac",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e3b1196913a94df9b3529aedf0ce6223",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cc5c4f24a44f4311b21effaf39e9a964",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c9e493065d1a4c338e04f9efd7f8aed5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/1 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "9259fd55992c498eb5f10a2f976800b4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d522d189222e475b8743c168bc494dcf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e68b0687e4a4f7caea4260e8e0a02d7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5e39c7362022429e8ebd1501809ecda3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fbcd555f4a1642d29b9d42577f31bbd6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "351d732b36184172b6684c28689e14ed",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2f02626694894bb387647df4dea44b6a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "626b16d33b2147f9a4432f4fb2ce934d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b03e3dad16984869805120ff12f519dd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ad9c208c1c054ab6b3b74da234843687",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/2 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0f6a074946bf43a3929481b0bdd78522",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c197a2ecd49c48a59c0ee0e10d54e9fd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c1cabfcd92c6499898159c649f3ec44b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a1e345844cf4c7d99711ab9543dd2fe",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "aa16f13935a54716929c59612d9e13b5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8ce33d60d64b4561b645fb1629d6fa34",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e34a82926353477eacd3f59db5c0b0a7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d0865432e904bf796b5819ceaeba130",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d4edb205f56f4002be0a16339a8c41f6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e0cc605264024aff98055649bb9d60c3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/3 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a8dcdd725ab445be99c9b2196f38abb7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f531f2f56d26469c9a8c9da9b635db7c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "47a6ac7db79d457bb41d4bc8422a138b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "415d3fc8e9204695b03359168e66c90c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "481487df6a1449fbac4c840bccb5229e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "56f286f8d9fa4585b332ede5746544d9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "99a5c44e509d4a1bbaceb85119b7f726",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "73378615b4214145b666cd1630a4415c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3906aac5c1c94f77971eab6c098e8432",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ada4c6efe1b5496e8bdfc132e94f8fce",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/4 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "265b497006584d209e7cb4808ffd3989",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7a46cb67fe9c45a7b3a31a5b35236307",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/ziqili/anaconda3/lib/python3.11/site-packages/joblib/externals/loky/process_executor.py:700: UserWarning: A worker stopped while some jobs were given to the executor. This can be caused by a too short worker timeout or by a memory leak.\n",
+      "  warnings.warn(\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dade619d09934d9fbbb836c86cb3521b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bd3ecd8002f54ae29d4933b139bbe0c3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b2927e7e93884a269353ce5e1088c20d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c0dda1cfc74e40b9807faca863a2e998",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8d8755fd70084d09995f1e5a811487ab",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ee3aad0256d34eb9b19e1d49cc977b20",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3d7ecc66f47c4627b21d764d20d45096",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ae3346cf1a644e4481fdc20ef9db25fc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/5 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5afbbaae3296403392824cd9e8fcaaa8",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "80cd38c31db448c2b75e4a94afc87950",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1874d676644d462ba329a627e8b6e370",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "942c7ea4b72f406fbff05f04df60ccb9",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "02ed668e9c1b4944bc86a5a0e0cc3152",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7495c783428b4cfca735c1bb1cb94de0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4937edf59abe4264ae8e81669d16df63",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4ffce9db83704bd39c152a578b3916e1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b7967fde9b3d4b93ab3752a84a9679e4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "25f02ee3cbf34602b78ca7fb50671779",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/6 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a19247dbb2c6419ea6021c447f2b28f0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "89742229fcb54516bb6da420fd3b09c7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/7 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0e13d0502ee44b20b7d5399b4db432dc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6b76bbb1359d433bb395cff0d456561a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/7 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1ad3006044a6433e85483a2961be1906",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7d761383dc7a4abf8814b22a2d2a6777",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/7 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "adcec7e064cc4bbca06b98a5c75d246f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c4c86c7bc60f4aebb8866554f75398de",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/7 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f9ecb298a5114fc0be3ddde425d45542",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6441df0fb13649b8a47483516d976753",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/7 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6ae92a50ae2445bf9f07464203b365a4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1de0cf485738482b907c010f7b16d892",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4a33528854df47b8a23a8b5c8e8d7ec7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "b2a47a5ebd724c289d27807961dbb42d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "980e27cb62e1446fb8cb153cad530bce",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "25d8dd37c86440819417ca79806c9f9a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e03499abe2064a2bb86dcc4d2f996d7c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d3f4aff489c74fc9ad1731a3a1a2855c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cfc0ca5e9c174198aa9682f9515eacaf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "029a69e7dc5d4abc9b8d7724d3292c01",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/8 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d4a236ea571b4e748664069e75b41504",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1a019b49c93f47f782d389030900bdc7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "49487a0d816a4e298b73e05957474263",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6330014f16094164b3c831d3bba484cf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "236c014bf68b46d1add2adb4e29d02ca",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f06ed796152b473aaa015acbe5ce05d5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "cda1d56af9ad4b99b92b520222dd56bc",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7c68b63452d744d8b6970f4f55cff15f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "17b58a6f2a1440ddbc8feff582aaa3d3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1fc2286ea768406d82ce41c8477ed858",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/9 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "30ec20d484f24df3a1d3b2dbc793a038",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "85689bc8a7e24f848f929848958c917b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "eb9dc6cb1637443289f080b2d96eaeb6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7e51a6f4612d4f289ccc53f2b3c6b6b6",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8ba629e366144060aedd901a49c3620a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e8c9075411274e34861052b141ab3a29",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6b6b87991ee74c659244ce2f354b8527",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0198464a90074ec2b305d03f4a49e799",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "23f107d6d78e4a0eb96a7b77553a7e0a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a745f6166ea2475db96683e4a3ccc2c4",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/10 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "6c0845b91c524d61b0aab23bab0736ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1925fdf215f9404a88681e84cfe8dccf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/11 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "080f3cfd32164df1883bc845f70ce93d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f6a86e89f0a9418bacc33dac4e8a35f0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/11 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8188d5fd128a4f77a339833d19fe0f26",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "5c3ef8add0604ed59e764ab5dca42f91",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/11 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bf8f658d85554c7bb102bf12b1de4645",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "501a8f2b71f64fb2983279bb76fb4d78",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/11 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0c15f9eabda642f8858fd1525234233a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0d20e98eb0794dcf883ce9e16e2b42c5",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/11 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c1a2d1c452f743ba881315de33e2b794",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "0a5f8655905f408090ac45b04637a786",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/12 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "421c66571f2c49b69c403d6becfec53d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "61466a49e9814ff890c341f34014899e",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/12 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "abd0f580f5e742aabbde5c465e426fdf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "19360deb052147be99f88585d88a7a1f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/12 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "21526c7c006d4a3ba17e1a5b2c563705",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "d0895aebd6b44cb594f3f5d860b11a00",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/12 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "3caf67a711cc4b61ae0365b59f3e8b91",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Backfitting:   0%|          | 0/200 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "27bf2bc488844480af7d98c1cfd715ee",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Inference:   0%|          | 0/12 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from time import time\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "n_jobs_values = np.arange(1,13)\n",
+    "performance_times_avg = []\n",
+    "\n",
+    "for n_jobs in n_jobs_values:\n",
+    "    times = []\n",
+    "    for _ in range(5): \n",
+    "        start_time = time()\n",
+    "\n",
+    "        mgwr_selector = Sel_BW(b_coords, b_y, b_X, multi=True,n_jobs=n_jobs) #add n_jobs\n",
+    "        mgwr_bw = mgwr_selector.search()\n",
+    "        mgwr_results = MGWR(b_coords, b_y, b_X, selector=mgwr_selector,n_jobs=n_jobs).fit() #add n_jobs\n",
+    "\n",
+    "        end_time = time()\n",
+    "        times.append(end_time - start_time)\n",
+    "    average_time = sum(times) / len(times)\n",
+    "    performance_times_avg.append(average_time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 1.0, 'MGWR Performance with Different n_jobs Values')"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjIAAAHHCAYAAACle7JuAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy81sbWrAAAACXBIWXMAAA9hAAAPYQGoP6dpAABvtklEQVR4nO3dd3hTZfsH8G/Ske500En3oqzKEugARIrsPRRREFw/XxQBUUFlOUDRVxFEVHxFWYq4EFSGCAjYAZRdRqET6ICOdM+c3x8lkdAW0jTtScL3c125tOecPLkzSu4+65YIgiCAiIiIyAhJxQ6AiIiISFdMZIiIiMhoMZEhIiIio8VEhoiIiIwWExkiIiIyWkxkiIiIyGgxkSEiIiKjxUSGiIiIjBYTGSIiIjJaTGTonpaTk4Px48fDxcUFEokEK1asEDuke87XX38NiUSCtLQ0ra89evRoywd20xNPPAF/f3+NYyUlJXjqqafg4eEBiUSCWbNmAeDnSRtpaWmQSCT4+uuvm3zfxYsXQyKR4MaNG/oPrIU09Pkh/WIiY+BU/3BLJBIcOnSo3nlBEODj4wOJRILhw4fXO19ZWYlVq1YhOjoaTk5OsLS0hJeXF0aOHIlvv/0WtbW1AIDc3FxIJBK8+OKL9dp48cUXIZFIsGjRonrnpkyZAgsLC5SVlQGo+6VVxSuRSCCTyRAaGoqFCxeioqJCq+f8wAMPaLTh7OyM+++/H1999RWUSqVWbWhr9uzZ2LVrF+bPn48NGzZg8ODBem2fdPPpp5/q9EV3N6ovQtXNxsYGvr6+GDFiBNatW4fKykqt2lm6dCm+/vprPPfcc9iwYQMef/xxAMb1eWqp19hYJSYmQiKR4I033mj0muTkZEgkEsyZM6cVI6O7MRc7ANKOlZUVNm/ejOjoaI3jBw4cwJUrVyCTyerd5/r16xgyZAiOHTuGQYMG4Y033oCzszOys7Px559/4tFHH8WlS5ewYMECuLm5ISQkpMFk6fDhwzA3N8fhw4cbPNe1a1fY2Nioj8lkMnz55ZcAAIVCgW3btuGtt97C5cuXsWnTJq2er7e3N5YtW6Z+HuvXr8eTTz6Jixcv4t1339WqDW389ddfGDVqFObOnau3NqlpHn/8cTzyyCMan+FPP/0Ubdq0wRNPPNEij7lmzRrY2dmhsrISV69exa5duzB9+nSsWLECO3bsgI+Pj/ratWvX1kug//rrL/Tu3btecm9Mn6eWfo0b4+fnh/LyclhYWLTq495Nt27dEBYWhm+//RZvv/12g9ds3rwZAPDYY4+1Zmh0NwIZtHXr1gkAhLFjxwpt2rQRqqurNc4//fTTQvfu3QU/Pz9h2LBhGucGDRokSKVS4ccff2yw7SNHjggbN25U/zxt2jTBzMxMKC4uVh8rKSkRzM3NhUcffVSws7MTampq1OeuXbsmABBmz56tPjZ16lTB1tZW43GUSqXQu3dvQSKRCNnZ2Xd9zv369RM6duyocay0tFTw9vYWbG1thaqqqru2cSfV1dVCZWWlIAiCIJFIhBkzZjSrvVuVl5cLtbW1emvvXtWxY0ehX79+9Y6rfh+OHDmiU7uLFi0SAAjXr1+vd27jxo2CVCoVevXqddd2AgIC6v2+CYL+P0+3flb1rbHX2JDd6f3Th7feeksAIMTGxjZ4vl27dkJYWFiT2pw6darg5+enh+ioMRxaMhKTJk1CXl4e9uzZoz5WVVWFH374AY8++mi962NjY7Fr1y4888wzGDt2bINt9ujRA5MnT1b/HB0djdraWsTFxamPxcfHo6amBnPnzkVJSQlOnDihPqfqobm9l+h2EokE0dHREAQBKSkpWj3f29nY2KB3794oLS3F9evXAQCFhYWYNWsWfHx8IJPJEBwcjPfee0/jr2fVePwHH3yAFStWICgoCDKZDJ9++ikkEgkEQcDq1avVQw0qKSkpmDBhApydndWP/dtvv2nEtH//fkgkEnz33Xd444030LZtW9jY2KCoqAhPPPEE7OzskJGRgeHDh8POzg5t27bF6tWrAQCnT5/Ggw8+CFtbW/j5+an/0lPJz8/H3Llz0blzZ9jZ2cHBwQFDhgzByZMnG4zh+++/xzvvvANvb29YWVlhwIABuHTpUr3XMT4+HkOHDoWTkxNsbW0RHh6Ojz/+WOOa8+fPY/z48XB2doaVlRV69OiBX3/99a7vUbdu3ep91jp37gyJRIJTp06pj23ZsgUSiQTnzp0DUH+OjL+/P86ePYsDBw6o35cHHnhAo93KykrMmTMHrq6usLW1xZgxY9SfC11NnjwZTz31FOLj4zV+z26d46B6vVNTU/Hbb7+p41M9h8Y+T835rCYlJQHQ7n1RxXH48OE7vj7avMa3ujW2L774Qh3b/fffjyNHjjTpdW5sjsxff/2FPn36wNbWFo6Ojhg1apT6M3K7GzduYOLEiXBwcICLiwtefPHFekPXe/bsQXR0NBwdHWFnZ4d27drhtddeu2Nsqn8Pb/99BIBjx47hwoUL6mu2bduGYcOGwcvLCzKZDEFBQXjrrbfUw/WNUX2G9u/fr3G8sddFm/e9uroaS5YsQUhICKysrODi4oLo6GiNz7Ep49CSkfD390dERAS+/fZbDBkyBADwxx9/QKFQ4JFHHsHKlSs1rt++fTuApnWBqhKSQ4cOISYmBkBdshIaGoquXbvC29sbhw8fRvfu3dXnbr3fnai+pJycnLSO53YpKSkwMzODo6MjysrK0K9fP1y9ehXPPvssfH198c8//2D+/PnIysqqN8ly3bp1qKiowDPPPAOZTIZu3bqp5zYMHDgQU6ZMUV+bk5ODyMhIlJWVYebMmXBxccE333yDkSNH4ocffsCYMWM02n7rrbdgaWmJuXPnorKyEpaWlgCA2tpaDBkyBH379sXy5cuxadMmPP/887C1tcXrr7+OyZMnY+zYsfjss88wZcoUREREICAgQP1cf/nlF0yYMAEBAQHIycnB559/jn79+iEpKQleXl4aMbz77ruQSqWYO3cuFAoFli9fjsmTJyM+Pl59zZ49ezB8+HB4enrixRdfhIeHB86dO4cdO3ao50adPXsWUVFRaNu2LebNmwdbW1t8//33GD16NH788cd6z/1Wffr0wbfffqv+OT8/H2fPnoVUKsXBgwcRHh4OADh48CBcXV3Rvn37BttZsWIFXnjhBdjZ2eH1118HALi7u2tc88ILL8DJyQmLFi1CWloaVqxYgeeffx5btmxpND5tPP744/jiiy+we/duDBw4sN759u3bY8OGDZg9eza8vb3x0ksvAQC6du3a6OepuZ9VZ2fnJr8vd3t9tHmNG7J582YUFxfj2WefhUQiwfLlyzF27FikpKQ0a6jozz//xJAhQxAYGIjFixejvLwcq1atQlRUFBITE+tNlp04cSL8/f2xbNkyxMXFYeXKlSgoKMD69esB1H2Ohw8fjvDwcLz55puQyWS4dOlSg8PjtwoICEBkZCS+//57fPTRRzAzM9N47gDUfzh+/fXXsLOzw5w5c2BnZ4e//voLCxcuRFFREd5//32dX4tbafu+L168GMuWLcNTTz2Fnj17oqioCEePHkViYmKDn2OTI3KPEN3FrV3pn3zyiWBvby+UlZUJgiAIEyZMEPr37y8IglBvaGnMmDECAKGwsFCjvfLycuH69evqW0FBgcZ5Nzc3YcCAAeqfBw0aJEybNk0QBEGYOHGiMGHCBPW5Hj16CCEhIRr3Vw0tqdq/dOmS8MEHHwgSiUTo1KmToFQq7/qc+/XrJ4SFhanbOHfunDBz5kwBgDBixAhBEOq6gG1tbYWLFy9q3HfevHmCmZmZkJGRIQiCIKSmpgoABAcHByE3N7feYwGoNxQwa9YsAYBw8OBB9bHi4mIhICBA8Pf3Vw8d7du3TwAgBAYGqt+TW18HAMLSpUvVxwoKCgRra2tBIpEI3333nfr4+fPnBQDCokWL1McqKirqDVGlpqYKMplMePPNN9XHVDG0b99eYwji448/FgAIp0+fFgRBEGpqaoSAgADBz8+v3nt+63syYMAAoXPnzkJFRYXG+cjIyHrv9e22bt0qABCSkpIEQRCEX3/9VZDJZMLIkSOFhx9+WH1deHi4MGbMGPXPqs94amqq+tjdhpZiYmI04p49e7ZgZmZW7/N+u7sNTRQUFAgANOJraGigoaFcQWj486SPz6q270tTXp+mDC2pYnNxcRHy8/PVx7dt2yYAELZv365VO7e2tW7dOvWxLl26CG5ubkJeXp762MmTJwWpVCpMmTJFfUz1/o0cOVKjzf/85z8CAOHkyZOCIAjCRx99pPMQ1OrVqwUAwq5du9THamtrhbZt2woRERHqY7f/zguCIDz77LOCjY2Nxvt0++dH9Tu7b98+jfs29Lpo+77fd999DX4e7xUcWjIiEydORHl5OXbs2IHi4mLs2LGjwWElACgqKgIA2NnZaRz/7LPP4Orqqr7d3psSFRWF+Ph41NbWQqlUIi4uDpGRkepzqr9oysrKcOLEiQZ7Y0pLS9XtBwcHY+7cuYiKisK2bds0utvv5Pz58+o22rdvj1WrVmHYsGH46quvAABbt25Fnz594OTkhBs3bqhvMTExqK2txd9//63R3rhx4+Dq6qrVY//+++/o2bOnxnOzs7PDM888g7S0NHVXv8rUqVNhbW3dYFtPPfWU+v8dHR3Rrl072NraYuLEierj7dq1g6Ojo8awm0wmg1Ra9+tZW1uLvLw8dfd4YmJivceZNm2auicIqOsdAaBu8/jx40hNTcWsWbPg6OiocV/Ve5Kfn4+//voLEydORHFxsfo1zcvLw6BBg5CcnIyrV682+rqpHlP12h88eBD3338/Bg4ciIMHDwKoG2I5c+aM+lpdPfPMMxqfpT59+qC2thbp6enNalf1+1JcXNysdm7V3M+qLu9LS70+Dz/8sEav6u2fM11kZWXhxIkTeOKJJ+Ds7Kw+Hh4ejoEDB+L333+vd58ZM2Zo/PzCCy8AgPpa1Wd827ZtTV7p+PDDD8PCwkJjeOnAgQO4evWqxlD8rb/zqvelT58+KCsrw/nz55v0mA1pyvvu6OiIs2fPIjk5udmPa4w4tGREXF1dERMTg82bN6OsrAy1tbUYP358g9fa29sDqNvvQi6Xq4+PGzcOnTp1AgC89NJL9cZzo6Oj8fPPP+PEiROwsLCAQqFAVFQUACAyMhLXrl1DWloaUlNTUVNT02AiY2VlpR7aunLlCpYvX47c3NxGv+wb4u/vj7Vr10IikcDKygohISFwc3NTn09OTsapU6caTU5yc3M1flYN2WgjPT0dvXr1qndcNRSSnp6ufg3v1LaVlVW9+ORyOby9vesldHK5HAUFBeqflUolPv74Y3z66adITU3VeJ9cXFzqPZavr6/Gz6ovG1Wbly9fBgCNuG936dIlCIKABQsWYMGCBQ1ek5ubi7Zt2zZ4zt3dHSEhITh48CCeffZZHDx4EP3790ffvn3xwgsvICUlBefOnYNSqWx2InO356urkpISAP/+/uhDcz+rurwvLfX6tES7quSqXbt29c61b98eu3btQmlpKWxtbdXHQ0JCNK4LCgqCVCpVD2E//PDD+PLLL/HUU09h3rx5GDBgAMaOHYvx48er/0BojIuLCwYNGoSff/4Zn332mXrFqLm5ucYfIGfPnsUbb7yBv/76S/2Ho4pCoWjSa9CQprzvb775JkaNGoXQ0FB06tQJgwcPxuOPP64ezjV1TGSMzKOPPoqnn34a2dnZGDJkSL2/rlXCwsIAAGfOnFEnIgDg4+OjXlqq+gvxVrfOk7G0tISzs7O6rS5dusDGxgaHDh1CamqqxvW3MjMzU8+xAYBBgwYhLCwMzz77rFaTRgHA1tZWo43bKZVKDBw4EK+88kqD50NDQzV+bkoS1VSNtX3r+Lo2xwVBUP//0qVLsWDBAkyfPh1vvfUWnJ2dIZVKMWvWrAb/wtSmzbtRtTt37lwMGjSowWuCg4Pv2EZ0dDT27t2L8vJyHDt2DAsXLkSnTp3g6OiIgwcP4ty5c7Czs0PXrl21jqsh+ni+DTlz5gyAuz/PpmjuZ1WX96WlXp+Ware5bv/DwNraGn///Tf27duH3377DTt37sSWLVvw4IMPYvfu3Y0+D5XHHnsMO3bswI4dOzBy5Ej8+OOPeOihh9TJaGFhIfr16wcHBwe8+eabCAoKgpWVFRITE/Hqq6/esReosV7p2/+obMr73rdvX1y+fBnbtm3D7t278eWXX+Kjjz7CZ599ptErbKqYyBiZMWPG4Nlnn0VcXNwdJzYOHz4c7777LjZt2qSRyNxNt27d1MmKTCZDRESE+hfP3Nwc999/Pw4fPozU1FS4ubnV+0e4IZ6enpg9ezaWLFmCuLg49O7dW+t4GhMUFISSkpI7Jju68vPzw4ULF+odV3UX+/n56f0xb/fDDz+gf//++N///qdxvLCwEG3atGlye0FBQQDqvqgbe80CAwMBABYWFjq/rn369MG6devw3Xffoba2FpGRkZBKpYiOjlYnMpGRkXf9ItF2CFLfNmzYAACNfnHoormfVX28Lw0R6zW+ner3qbHfuTZt2mj0xgB1vVy39lxdunQJSqVSY1KwVCrFgAEDMGDAAHz44YdYunQpXn/9dezbt++ur+PIkSNhb2+PzZs3w8LCAgUFBRrDSvv370deXh5++ukn9O3bV31c9Qfenah6sQoLCzWO3z7s19T33dnZGdOmTcO0adNQUlKCvn37YvHixfdEIsM5MkbGzs4Oa9asweLFizFixIhGr4uKisLAgQPxxRdfYNu2bQ1e09BfUebm5ujVqxcOHz6Mw4cPq+fHqERGRuLvv/9GXFxckxKkF154ATY2NnrbzG7ixInqJea3KywsRE1Njc5tDx06FAkJCYiNjVUfKy0txRdffAF/f3906NBB57a1ZWZmVu/92bp16x3nqNxJt27dEBAQgBUrVtT7B1T1OG5ubnjggQfw+eefIysrq14b2ixvVg0ZvffeewgPD1cPa/bp0wd79+7F0aNHtRpWsrW1rRdnS9u8eTO+/PJLREREYMCAAXprt7mfVX28Lw0R4zVuiKenJ7p06YJvvvlGI54zZ85g9+7dGDp0aL37qLYxUFm1ahUAqFd05ufn17tPly5dAECr3Zutra0xZswY/P7771izZg1sbW0xatQo9XlVIn7r72hVVRU+/fTTu7bt5+cHMzOzenOjbr9vU973vLw8jXN2dnYIDg7WeqdqY8ceGSM0depUra7buHEjBg8ejNGjR2PIkCGIiYmBk5OTemffv//+W/2Lf6vo6Gjs27cPAOolK5GRkeodd7VZdq3i4uKCadOm4dNPP8W5c+caXXqrrZdffhm//vorhg8fjieeeALdu3dHaWkpTp8+jR9++AFpaWk69VwAwLx589TL3GfOnAlnZ2d88803SE1NxY8//njXMXZ9GD58ON58801MmzYNkZGROH36NDZt2qT+K62ppFIp1qxZgxEjRqBLly6YNm0aPD09cf78eZw9e1b9Jbt69WpER0ejc+fOePrppxEYGIicnBzExsbiypUr9faxuV1wcDA8PDxw4cIF9QRMoK7r+9VXXwUArRKZ7t27Y82aNXj77bcRHBwMNzc3PPjggzo994b88MMPsLOzQ1VVlXpn38OHD+O+++7D1q1b9fY4gH4+q819XxrS0q9xU7z//vsYMmQIIiIi8OSTT6qXX8vlcixevLje9ampqRg5ciQGDx6M2NhYbNy4EY8++ijuu+8+AMCbb76Jv//+G8OGDYOfnx9yc3Px6aefwtvbW+t/tx577DGsX78eu3btwuTJkzV6hSIjI+Hk5ISpU6di5syZkEgk2LBhg1ZDbHK5HBMmTMCqVasgkUgQFBSEHTt21JsrBWj/vnfo0AEPPPAAunfvDmdnZxw9ehQ//PADnn/+ea2eq9ETZa0UaU3bnUwbWw5aXl4urFixQoiIiBAcHBwEc3NzwcPDQxg+fLiwadMmjZ16VXbt2iUAEMzNzYXS0lKNc3l5eYJEIhEACPHx8fXu29DOviqXL18WzMzMhKlTp97xuTS0s29DiouLhfnz5wvBwcGCpaWl0KZNGyEyMlL44IMP1Lv/qpY0vv/++w22gQaWy6piHT9+vODo6ChYWVkJPXv2FHbs2KFxjWoZ5datW+vdv7HXobHndvv7V1FRIbz00kuCp6enYG1tLURFRQmxsbFCv379NJbMNhZDQ0s5BUEQDh06JAwcOFCwt7cXbG1thfDwcGHVqlX1nvuUKVMEDw8PwcLCQmjbtq0wfPhw4YcffqgXd0MmTJggABC2bNmiPlZVVSXY2NgIlpaWQnl5ucb1DS2/zs7OFoYNGybY29sLANTPubHfh8aWtN5OtXxXdbOyshK8vb2F4cOHC1999ZXGMleV5i6/FgT9fFa1eV+a8vo09ho35E6x4batA+6msc/mn3/+KURFRQnW1taCg4ODMGLECPVSfhXV+5eUlCSMHz9esLe3F5ycnITnn39e43O1d+9eYdSoUYKXl5dgaWkpeHl5CZMmTaq3BP5OampqBE9PTwGA8Pvvv9c7f/jwYaF3796CtbW14OXlJbzyyivqfztvfZ0b+vxcv35dGDdunGBjYyM4OTkJzz77rHDmzJkGXxdt3ve3335b6Nmzp+Do6ChYW1sLYWFhwjvvvNPsXdCNhUQQRJ6lRURE94zLly8jODgYGzZsYM0i0gvOkSEiolajmu+h69Av0e04R4aIiJqtqqqqwUm2t/rxxx/x7bffquuXEekDExkiImq2f/75B/3797/jNWZmZggNDcXWrVsb3QOLqKk4R4aIiJqtoKAAx44du+M1HTt2hKenZytFRPcKJjJERERktDjZl4iIiIyWyc+RUSqVuHbtGuzt7Q1mS24iIiK6M0EQUFxcDC8vrztuRGryicy1a9fURRKJiIjIuGRmZsLb27vR8yafyNjb2wOoeyEcHBxEjoaIiIi0UVRUBB8fH/X3eGNMPpFRDSc5ODgwkSEiIjIyd5sWwsm+REREZLSYyBAREZHRYiJDRERERouJDBERERktJjJERERktJjIEBERkdFiIkNERERGi4kMERERGS0mMkRERGS0TH5n33tVrVJAQmo+cosr4GZvhZ4BzjCTsmgmERGZFiYyJmjnmSws2Z6ELEWF+pin3AqLRnTA4E6eIkZGRESkXxxaMjE7z2ThuY2JGkkMAGQrKvDcxkTsPJMlUmRERET6x0TGhNQqBSzZngShgXOqY0u2J6FW2dAVRERExoeJjAlJSM2v1xNzKwFAlqICCan5rRcUERFRC2IiY0JyixtPYnS5joiIyNAxkTEhbvZWer2OiIjI0DGRMSE9A5zhKW88SZGgbvVSzwDn1guKiIioBTGRMSFmUgke6+17x2sWjejA/WSIiMhkMJExIRXVtfgp8SoAwNrCTOOcuVSCNY914z4yRERkUrghnglZve8SLl8vRRs7GXbN6oOLOSW4fL0Eb/xyBjVKAT38OaRERESmhT0yJuJcVhHW7L8MAHhrVEe42MkQEeSCx3r7oYOnAwDg8KUbYoZIRESkd0xkTEBNrRKv/ngKNUoBgzt6YEhnzeGjPqFtAAB/X2QiQ0REpoWJjAn46nAqTl1RwMHKHG+O6ljvfJ9gVwDAweTrEATu6ktERKaDiYyRS7tRiv/uvggAeGN4B7g51F9+3cPfCTJzKXKLK5GcW9LaIRIREbUYJjJGTKkU8OqPp1BZo0R0cBtM6O7d4HVWFmboFegCAPj74vXWDJGIiKhFMZExYt8dyUR8aj6sLcywbGxnSCSN7w/TN6RunszBZM6TISIi08FExkhlKcqx7PdzAICXB7WDj7PNHa/vE1I3TyY+NQ8V1bUtHh8REVFrYCJjhARBwBs/n0FxZQ26+jpiaqT/Xe8T6m4HN3sZKqqVOJZe0PJBEhERtQImMkZo+6ks7D2fC0szKZaPC9eq5IBEIkH0zeGlv5M5T4aIiEwDExkjk19ahcW/ngUAPP9gMELc7bW+b9+bw0sHuZ8MERGZCCYyRubN7WeRX1qFMA97/F+/oCbdNyq4rkcmKasIN0oqWyI8IiKiVsVExoj8dT4Hv5y4BqkEeG9cOCzNm/b2udrLWK6AiIhMChMZI1FcUY3Xfz4DAHiqTyDu83HUqR2WKyAiIlPCRMZIvLfzPLIUFfBzscHsmFCd21HPk2G5AiIiMgGiJjLFxcWYNWsW/Pz8YG1tjcjISBw5ckR9XhAELFy4EJ6enrC2tkZMTAySk5NFjFgc8Sl52BiXAQBYNrYzrC3NdG6ru58TrCzqyhVczGG5AiIiMm6iJjJPPfUU9uzZgw0bNuD06dN46KGHEBMTg6tXrwIAli9fjpUrV+Kzzz5DfHw8bG1tMWjQIFRUVIgZdquqqK7FvJ9OAwAm9fRFZFCbZrVnZWGGngF15QoOchk2EREZOdESmfLycvz4449Yvnw5+vbti+DgYCxevBjBwcFYs2YNBEHAihUr8MYbb2DUqFEIDw/H+vXrce3aNfzyyy9ihd3qVvyZjNQbpXB3kGH+0DC9tMlyBUREZCpES2RqampQW1sLKyvNas3W1tY4dOgQUlNTkZ2djZiYGPU5uVyOXr16ITY2ttF2KysrUVRUpHEzVqevKLD2YAoA4J3RneFgZaGXdlmugIiITIVoiYy9vT0iIiLw1ltv4dq1a6itrcXGjRsRGxuLrKwsZGdnAwDc3d017ufu7q4+15Bly5ZBLperbz4+Pi36PFpKda0Sr/x4CrVKAcPDPRHTwf3ud9ISyxUQEZGpEHWOzIYNGyAIAtq2bQuZTIaVK1di0qRJkEp1D2v+/PlQKBTqW2Zmph4jbj1f/J2Cc1lFcLSxwOKRHfXatkQiUffKsFwBEREZM1ETmaCgIBw4cAAlJSXIzMxEQkICqqurERgYCA8PDwBATk6Oxn1ycnLU5xoik8ng4OCgcTM2l3JL8PGfdauzFo3ogDZ2Mr0/Rt+b+8mwXAERERkzg9hHxtbWFp6enigoKMCuXbswatQoBAQEwMPDA3v37lVfV1RUhPj4eERERIgYbctSKgXM+/EUqmqVeKCdK0Z3adsij3NruYLrxSxXQERExknURGbXrl3YuXMnUlNTsWfPHvTv3x9hYWGYNm0aJBIJZs2ahbfffhu//vorTp8+jSlTpsDLywujR48WM+wWtTE+HUfTC2BraYZ3xnSGRHL3yta6aGPHcgVERGT8zMV8cIVCgfnz5+PKlStwdnbGuHHj8M4778DCom51ziuvvILS0lI888wzKCwsRHR0NHbu3FlvpZOpuFJQhvf+OA8AmDckDG0drVv08fqEtkFSVhEOJt/A6K4t0/NDRETUkiSCie9TX1RUBLlcDoVCYdDzZQRBwBPrjuDAxeu4398JW56JgFTaMr0xKocv3cDkL+PhZi9D/GsDWqz3h4iIqKm0/f42iDkyBPx8/CoOXLwOS3Mp3h0X3uJJDMByBUREZPyYyBiA68WVeHNHEgBgVkwIglztWuVxrSzM0IvlCoiIyIgxkTEAi7efRWFZNTp6OeDpPoGt+th9bpYr+JvlCoiIyAgxkRHZrrPZ+O1UFsykErw3LhwWZq37lqjLFaSwXAERERkfJjIiUpRXY8EvZwAAz/YNRKe28laPQVWuoLKG5QqIiMj4MJER0bLfzyG3uBKBbWwxc0CIKDGwXAERERkzJjIiOXzpBr47UlcH6r3x4bCyMBMtFpYrICIiY8VERgRlVTWY/9NpAMCUCD/c7+8sajwsV0BERMaKiYwIPtx9ERn5ZfCSW+GVwWFih4M2djJ09GK5AiIiMj5MZFrZ8YwCfHU4FQDwztjOsJOJWiVCjfNkiIjIGDGRaUVVNUq8+uMpKAVgbNe26N/OTeyQ1FT7yRxKvgETr1pBREQmhIlMK/p0/yVczCmBi60lFgzvIHY4GliugIiIjBETmVZyIbsYq/ddAgAsGdURTraWIkekieUKiIjIGDGRaQW1SgGv/HgK1bUCBnZwx7DOnmKH1CCWKyAiImPDRKYVrDucipOZhbC3MsfboztBImn5yta66BvKcgVERGRcmMi0sIy8Mnyw+wIA4LWh7eHuYCVyRI0LcbODu0NduYKjaSxXQEREho+JTAsSBAHzfz6FimolIgJd8Mj9PmKHdEcSiQTRwXW9MpwnQ0RExoCJTAvaevQKDl/Kg5WFFMvGdjbYIaVbqcsVcJ4MEREZASYyLSSnqAJv/ZYEAHhpYDv4t7EVOSLtsFwBEREZEyYyLUAQBCz45QyKK2pwn7cc06L8xQ5JayxXQERExoSJTAv440w2diflwFwqwXvjw2FuZlwvM8sVEBGRsTCub1gjUFhWhYXbzgAA/tM/GGEeDiJH1HR9Q/6dJ8NyBUREZMiYyOjZWzvO4UZJFULc7DCjf5DY4eiku39duYLrxZW4kFMsdjhERESNYiKjRwcuXsePiVcgkQDvjQ+HzNxM7JB0IjO/pVzBRc6TISIiw8VERk9KKmvw2k+nAQDTIgPQzddJ5IiaR1Wu4CAn/BIRkQFjIqMnH+y6gKuF5fB2ssbcQaFih9NsLFdARETGgImMHhxNy8c3sWkAgHfHhsPG0lzcgPSA5QqIiMgYMJHRQa1SQOzlPGw7cRUHLubilR9OQhCAiT28EX1zSMbYSSQS9TJslisgIiJDZfxdB61s55ksLNmehCxFhcZxBytzvD60g0hRtYw+IW3ww7Er+Dv5BuaLHQwREVED2CPTBDvPZOG5jYn1khgAKKqoQWyKaU2MVZUrOMdyBUREZKCYyGipVilgyfYkNLY9nATAku1JqFWazgZyLFdARESGjomMlhJS8xvsiVERAGQpKpCQmt96QbUClisgIiJDxkRGS7nFjScxulxnLFiugIiIDBkTGS252Vvp9TpjwXIFRERkyJjIaKlngDM85VaQNHJeAsBTboWeAc6tGVaLk5mboXcgyxUQEZFhYiKjJTOpBItG1C2vvj2ZUf28aEQHmEkbS3WMF+fJEBGRoWIi0wSDO3lizWPd4CHXHD7ykFthzWPdMLiTp0iRtSxV3aWE1HyWKyAiIoPCDfGaaHAnTwzs4IGE1HzkFlfAzb5uOMkUe2JUVOUKcooqcTStwGR2LyYiIuPHHhkdmEkliAhywagubRER5GLSSQzAcgVERGS4RE1kamtrsWDBAgQEBMDa2hpBQUF46623NJb5CoKAhQsXwtPTE9bW1oiJiUFycrKIUd+bVMNLfydzwi8RERkOUROZ9957D2vWrMEnn3yCc+fO4b333sPy5cuxatUq9TXLly/HypUr8dlnnyE+Ph62trYYNGgQKipMa78WQxd9S7kCU9srh4iIjJeoicw///yDUaNGYdiwYfD398f48ePx0EMPISEhAUBdb8yKFSvwxhtvYNSoUQgPD8f69etx7do1/PLLL2KGfs9xsZOhU1uWKyAiIsMiaiITGRmJvXv34uLFiwCAkydP4tChQxgyZAgAIDU1FdnZ2YiJiVHfRy6Xo1evXoiNjW2wzcrKShQVFWncSD+ig2/Ok+F+MkREZCBETWTmzZuHRx55BGFhYbCwsEDXrl0xa9YsTJ48GQCQnZ0NAHB3d9e4n7u7u/rc7ZYtWwa5XK6++fj4tOyTuIeoyxVcYrkCIiIyDKImMt9//z02bdqEzZs3IzExEd988w0++OADfPPNNzq3OX/+fCgUCvUtMzNTjxHf21iugIiIDI2o+8i8/PLL6l4ZAOjcuTPS09OxbNkyTJ06FR4eHgCAnJwceHr+u9lcTk4OunTp0mCbMpkMMpmsxWO/F6nKFey/cB0HL95AmIeD2CEREdE9TtQembKyMkilmiGYmZlBqVQCAAICAuDh4YG9e/eqzxcVFSE+Ph4RERGtGivVYbkCIiIyJKL2yIwYMQLvvPMOfH190bFjRxw/fhwffvghpk+fDqBuI7ZZs2bh7bffRkhICAICArBgwQJ4eXlh9OjRYoZ+z+p7W7kCKwszkSMiIqJ7maiJzKpVq7BgwQL85z//QW5uLry8vPDss89i4cKF6mteeeUVlJaW4plnnkFhYSGio6Oxc+dOWFlZ3aFlainBbnbwcLBCdlEFjqTlq3toiIiIxCARTHz5SVFREeRyORQKBRwcOKdDH+ZuPYkfjl3Bs30DMX9oe7HDISIiE6Tt9zdrLVGTsVwBEREZCiYy1GQsV0BERIaCiQw1GcsVEBGRoWAiQzpRTfJluQIiIhITExnSya3zZEx8vjgRERkwJjKkk+5+TrC2MMONkkqcz2a5AiIiEgcTGdKJzNwMvQKdAQCHuHqJiIhEwkSGdMZyBUREJDYmMqSz28sVEBERtTYmMqQzVbmCyholjqTlix0OERHdg5jIkM4kEol69dJBzpMhIiIRMJGhZukTenOezEXOkyEiotbHRIaaJSrIBQBwPruY5QqIiKjVMZGhZmG5AiIiEpN5U++gVCpx4MABHDx4EOnp6SgrK4Orqyu6du2KmJgY+Pj4tEScZMD6hLjizNUiHLx4A2O6eosdDhER3UO07pEpLy/H22+/DR8fHwwdOhR//PEHCgsLYWZmhkuXLmHRokUICAjA0KFDERcX15Ixk4FhuQIiIhKL1j0yoaGhiIiIwNq1azFw4EBYWFjUuyY9PR2bN2/GI488gtdffx1PP/20XoMlw3R7uYL2ng5ih0RERPcIiaDln9Dnzp1D+/bttWq0uroaGRkZCAoKalZw+lBUVAS5XA6FQgEHB37BtpRp6xKw78J1vDY0DM/0Ff99JyIi46bt97fWQ0vaJjEAYGFhYRBJDLWe6JvlCrifDBERtSadVi3t3LkThw4dUv+8evVqdOnSBY8++igKCgr0FhwZD5YrICIiMeiUyLz88ssoKioCAJw+fRovvfQShg4ditTUVMyZM0evAZJxYLkCIiISg06JTGpqKjp06AAA+PHHHzF8+HAsXboUq1evxh9//KHXAMk4sFwBERGJQadExtLSEmVlZQCAP//8Ew899BAAwNnZWd1TQ/celisgIqLW1uQN8QAgOjoac+bMQVRUFBISErBlyxYAwMWLF+HtzQ3R7lXRwW0gkdwsV1BUATcHK7FDIiIiE6dTj8wnn3wCc3Nz/PDDD1izZg3atm0LAPjjjz8wePBgvQZIxsPZ1hKdvOQAgEMsV0BERK1Apx4ZX19f7Nixo97xjz76qNkBkXGLDmmD01cVOJR8A2O7sXeOiIhaltaJTFPmvnDjuXtXn5A2WLP/srpcgUQiETskIiIyYVonMo6Ojlp/KdXWch+RexXLFRARUWvSOpHZt2+f+v/T0tIwb948PPHEE4iIiAAAxMbG4ptvvsGyZcv0HyUZDZm5GXoHOmPfhes4mHydiQwREbUorWst3WrAgAF46qmnMGnSJI3jmzdvxhdffIH9+/frK75mY62l1vfVoVS8uSMJfULaYMOTvcQOh4iIjJDeay3dKjY2Fj169Kh3vEePHkhISNClSTIhfUPrNsaLZ7kCIiJqYTolMj4+Pli7dm29419++SV8fHyaHRQZtyDXunIFVTVKJKSyXAEREbUcnZZff/TRRxg3bhz++OMP9OpVN3SQkJCA5ORk/Pjjj3oNkIyPqlzB1mNXcOjSDfS9ueMvERGRvunUIzN06FAkJydjxIgRyM/PR35+PkaMGIGLFy9i6NCh+o6RjBDLFRARUWvQqUcGALy9vbF06VJ9xkImhOUKiIioNeicyBQWFiIhIQG5ublQKpUa56ZMmdLswMi4qcoVnL6qwKFL3OWXiIhahk6JzPbt2zF58mSUlJTAwcFBY6M8iUTCRIYA1O3ye/qqAgdZroCIiFqITnNkXnrpJUyfPh0lJSUoLCxEQUGB+pafz1UqVKdPSN08mYM3yxUQERHpm06JzNWrVzFz5kzY2NjoOx4yId38HDXKFRAREembTonMoEGDcPTo0WY/uL+/PyQSSb3bjBkzAAAVFRWYMWMGXFxcYGdnh3HjxiEnJ6fZj0utQ1WuAAAOJnP1EhER6Z9Oc2SGDRuGl19+GUlJSejcuTMsLCw0zo8cOVKrdo4cOaJRYPLMmTMYOHAgJkyYAACYPXs2fvvtN2zduhVyuRzPP/88xo4di8OHD+sSNomgT4jrzbpLN/BM3yCxwyEiIhOjU60lqbTxjhyJRKJz9etZs2Zhx44dSE5ORlFREVxdXbF582aMHz8eAHD+/Hm0b98esbGx6N27t1ZtstaSuC7lFiPmw79haS7FqUUPwcrCTOyQiIjICLRorSWlUtnoTdckpqqqChs3bsT06dMhkUhw7NgxVFdXIyYmRn1NWFgYfH19ERsb22g7lZWVKCoq0riReIJc7eApZ7kCIiJqGTolMi3hl19+QWFhIZ544gkAQHZ2NiwtLeHo6Khxnbu7O7KzsxttZ9myZZDL5eobaz+JS1WuAOA8GSIi0j+dE5kDBw5gxIgRCA4ORnBwMEaOHImDBw/qHMj//vc/DBkyBF5eXjq3AQDz58+HQqFQ3zIzM5vVHjVf9C3LsI1NrVJA7OU8bDtxFbGX81Cr5DJyIiJDotNk340bN2LatGkYO3YsZs6cCQA4fPgwBgwYgK+//hqPPvpok9pLT0/Hn3/+iZ9++kl9zMPDA1VVVSgsLNTolcnJyYGHh0ejbclkMshksqY9IWpRxlquYOeZLCzZnoQsRYX6mKfcCotGdMDgTp4iRkZERCo69ci88847WL58ObZs2YKZM2di5syZ2LJlC95991289dZbTW5v3bp1cHNzw7Bhw9THunfvDgsLC+zdu1d97MKFC8jIyEBERIQuYZNIVOUKAODQJePoldl5JgvPbUzUSGIAIFtRgec2JmLnmSyRIiMiolvplMikpKRgxIgR9Y6PHDkSqampTWpLqVRi3bp1mDp1KszN/+0gksvlePLJJzFnzhzs27cPx44dw7Rp0xAREaH1iiUyHP/OkzH8RKZWKWDJ9iQ0NIikOrZkexKHmYiIDIBOiYyPj49GT4nKn3/+2eTJtX/++ScyMjIwffr0euc++ugjDB8+HOPGjUPfvn3h4eGhMfxExuPWcgVKA08AElLz6/XE3EoAkKWo4CosIiIDoNMcmZdeegkzZ87EiRMnEBkZCaBujszXX3+Njz/+uEltPfTQQ43W4bGyssLq1auxevVqXcIkA9LNzxE2lv+WK+jgZbh7+pzILNDqutzixpMdIiJqHTolMs899xw8PDzw3//+F99//z0AoH379tiyZQtGjRql1wDJNNSVK3DBX+dzcTD5ukEmMueyirBybzL+ONP48v5budkbx6RlIiJTplMiAwBjxozBmDFj9BkLmbjo4Db463wuDl26gWf7GU65goYSGCsLKSqqlQ1eLwHgIbdCzwDnVoqQiIgao1Mic+TIESiVSvTq1UvjeHx8PMzMzNCjRw+9BEempW9o3YTf+NR8VFTXil6u4PYERiIBhnb2xMwHQ5B6owTPbUwEgAYn/S4a0QFmUkkrRktERA3RabLvjBkzGtxo7urVq+rK1US3M5RyBeeyivDcxmMY8vFB/HEmGxIJMCzcEztf7IvVj3ZDOw97DO7kiTWPdYOHXHP4yNJMgjWPdeM+MkREBkKnHpmkpCR069at3vGuXbsiKSmp2UGRaVKVK/j+6BUcTL6OvqGurfr4SdfqemB2nq3fA9POw77e9YM7eWJgBw8kpObjzFUF3vn9HAQAD7Rza9W4iYiocTolMjKZDDk5OQgMDNQ4npWVpbEXDNHt+oS43kxkWm8/maYmMLcyk0oQEeSC3oHOWHswBbnFlUjMKEBkUJvWCJ2IiO5Cp6zjoYcewvz587Ft2zbI5XU7thYWFuK1117DwIED9RogmZaoVixX0FACM6yzJ2YOCEGo+50TmNtJJHUJzbYT1xCXks9EhojIQOiUyHzwwQfo27cv/Pz80LVrVwDAiRMn4O7ujg0bNug1QDItqnIFp68qcOjSDYzt5q33x9BnAnOr3oE3E5nLeQDzdSIig6BTItO2bVucOnUKmzZtwsmTJ2FtbY1p06Zh0qRJsLCw0HeMZGL6hLTB6asKHEzWbyLTUgmMSkSgCwDgRGYhyqtqYW0p7qorIiJqxj4ytra2eOaZZ/QZC90j+oS44tP9l9XlCqTNXMbc0gmMip+LDTwcrJBdVIHEjAJEBXN4iYhIbDotvwaADRs2IDo6Gl5eXkhPTwdQVxtp27ZteguOTNPt5Qp0lXStCP+34RiGrjyInWfrllEPD/fErll98cmj3fSaxAD/zpMBgLiUPL22TUREutEpkVmzZg3mzJmDIUOGoKCgALW1tQAAJycnrFixQp/xkQlSlSsAgIPJ15t8/9ZOYG7VO7BuN9/Yy0xkiIgMgU6JzKpVq7B27Vq8/vrrGsute/TogdOnT+stODJdfULqhmWasgxbzARGJSKwLu6TVwpRVlXT4o9HRER3ptMcmdTUVPVqpVvJZDKUlpY2OygyfX1C6jbDS0i7e7mC1poDow0fZ2t4ya1wTVGBY+kF6udBRETi0CmRCQgIwIkTJ+Dn56dxfOfOnWjfvr1eAiPTFuRqCw8HGbKLKvHxn8noG+qKngHOGvWLDCmBUZFIJOgd5IKfEq8iLiWPiQwRkch0SmTmzJmDGTNmoKKiAoIgICEhAd9++y2WLVuGL7/8Ut8xkgnadTYbivK6oZk1By5jzYHL8JRbYdGIDvB1tjW4BOZWvQPrEhnOkyEiEp9OicxTTz0Fa2trvPHGGygrK8Ojjz4KLy8vfPzxx3jkkUf0HSOZmJ1nsvDcxsR6VaWzFBX4v5sVpwHDS2BUVPvJnLqiQGllDWxlLMtBRCQWnf8Fnjx5MiZPnoyysjKUlJTAzY2F9OjuapUClmxPqpfE3G5YZw+8GBNqUAmMio+zDdo6WuNqYTmOphegXysXvyQion/ptGqpvLwcZWVlAAAbGxuUl5djxYoV2L17t16DI9OTkJqPLEXFXa97rLe/QSYxKqr9ZDi8REQkLp0SmVGjRmH9+vUA6opF9uzZE//9738xatQorFmzRq8BkmnJLb57EtOU68Si2geHG+MREYlLp0QmMTERffr0AQD88MMP8PDwQHp6OtavX4+VK1fqNUAyLW722lW71vY6sah6ZE5fVaCkkvvJEBGJRadEpqysDPb2dd3+u3fvxtixYyGVStG7d291uQKihvQMcIan3AqNVVeSAPCUW6FngHNrhtVkbR2t4etsg1qlgCNp+WKHQ0R0z9IpkQkODsYvv/yCzMxM7Nq1Cw899BAAIDc3Fw4ODnoNkEyLmVSCRSM6AEC9ZEb186IRHTT2kzFUqnIFcZwnQ0QkGp0SmYULF2Lu3Lnw9/dHr169EBERAaCud6ahHX+JbjW4kyfWPNYNHnLN4SMPuRXWPNYNgzt5ihRZ07CAJBGR+CSCINxtJWyDsrOzkZWVhfvuuw9SaV0+lJCQAAcHB4SFhek1yOYoKiqCXC6HQqFgb5GBqVUKSEjNR25xBdzsrert7GvoshTliFj2F6QS4MSih+BgZSF2SEREJkPb72+d95Hx8PCAh4eHxrGePXvq2hzdg8ykEnWvhjHylFvD38UGaXllOJqWjwfD3MUOiYjonqP10NL//d//4cqVK1pdu2XLFmzatEnnoIiMhWoZNveTISISh9Y9Mq6urujYsSOioqIwYsQI9OjRA15eXrCyskJBQQGSkpJw6NAhfPfdd/Dy8sIXX3zRknETGYSIIBd8dyQTcSlcuUREJIYmzZHJycnBl19+ie+++w5JSUka5+zt7RETE4OnnnoKgwcP1nuguuIcGWpJOUUV6LV0L6QS4PjChyC35jwZIiJ90Pb7W+fJvgUFBcjIyEB5eTnatGmDoKAgSCSGN1GTiQy1tAc/2I+UG6X4ckoPxHTgPBkiIn1o8cm+Tk5OcHJy0vXuRCajV6ALUm6UIjYlj4kMEVEr02kfGSL6F/eTISISDxMZombqfbOcQlJWEQrLqkSOhojo3sJEhqiZ3BysEORqC0EAElK5eomIqDUxkSHSA/V+MhxeIiJqVUxkiPTg33ky7JEhImpNOiUyOTk5ePzxx+Hl5QVzc3OYmZlp3IjuNb0C6hKZc1lFKCjlPBkiotai0/LrJ554AhkZGViwYAE8PT0Ncv8Yotbkai9DiJsdknNLEJ+aj8GdPO5+JyIiajadEplDhw7h4MGD6NKli57DITJevQNdkJxbgriUPCYyREStRKehJR8fH+i4IXA9V69exWOPPQYXFxdYW1ujc+fOOHr0qPq8IAhYuHAhPD09YW1tjZiYGCQnJ+vlsYn0ifvJEBG1Pp0SmRUrVmDevHlIS0tr1oMXFBQgKioKFhYW+OOPP5CUlIT//ve/GjsGL1++HCtXrsRnn32G+Ph42NraYtCgQaioqGjWYxPpW6+b+8mczy5GXkmlyNEQEd0bdKq15OTkhLKyMtTU1MDGxgYWFpqF8vLztVu5MW/ePBw+fBgHDx5s8LwgCPDy8sJLL72EuXPnAgAUCgXc3d3x9ddf45FHHrnrY7DWErWmQR/9jQs5xVgzuRuGdPYUOxwiIqPVorWWVqxYoWtcGn799VcMGjQIEyZMwIEDB9C2bVv85z//wdNPPw0ASE1NRXZ2NmJiYtT3kcvl6NWrF2JjYxtMZCorK1FZ+e9fw0VFRXqJlUgbEUEuuJBTjNiUPCYyREStQKdEZurUqXp58JSUFKxZswZz5szBa6+9hiNHjmDmzJmwtLTE1KlTkZ2dDQBwd9csxOfu7q4+d7tly5ZhyZIleomPqKl6Bzrj63/SEHuZ82SIiFqDzhviXb58GW+88QYmTZqE3NxcAMAff/yBs2fPat2GUqlEt27dsHTpUnTt2hXPPPMMnn76aXz22We6hoX58+dDoVCob5mZmTq3RdRUqv1kknNLcIPzZIiIWpxOicyBAwfQuXNnxMfH46effkJJSQkA4OTJk1i0aJHW7Xh6eqJDhw4ax9q3b4+MjAwAgIdH3RLWnJwcjWtycnLU524nk8ng4OCgcSNqLU62lgjzsAfA1UtERK1Bp0Rm3rx5ePvtt7Fnzx5YWlqqjz/44IOIi4vTup2oqChcuHBB49jFixfh5+cHAAgICICHhwf27t2rPl9UVIT4+HhEREToEjpRi+MybCKi1qNTInP69GmMGTOm3nE3NzfcuHFD63Zmz56NuLg4LF26FJcuXcLmzZvxxRdfYMaMGQAAiUSCWbNm4e2338avv/6K06dPY8qUKfDy8sLo0aN1CZ2oxakLSHKeDBFRi9Npsq+joyOysrIQEBCgcfz48eNo27at1u3cf//9+PnnnzF//ny8+eabCAgIwIoVKzB58mT1Na+88gpKS0vxzDPPoLCwENHR0di5cyesrKx0CZ2oxfUKcIZEAly+Xorc4gq42fOzSkTUUnTaR2bu3LmIj4/H1q1bERoaisTEROTk5GDKlCmYMmVKk+bJtDTuI0NiGPrxQSRlFWHlpK4YeZ+X2OEQERkdbb+/dRpaWrp0KcLCwuDj44OSkhJ06NABffv2RWRkJN544w2dgyYyFZwnQ0TUOnRKZCwtLbF27VqkpKRgx44d2LhxI86fP48NGzagqqpK3zESGR3VPJk4zpMhImpROiUyM2fOBFBXPHLo0KGYOHEiQkJCUFpaiqFDh+o1QCJj1PPmPJmUG6XIKWJdMCKilqJTIvPbb7/VmwdTWlqKwYMHo6amRi+BERkzubUFOnrVjelyeImIqOXolMjs3r0ba9euVddcKi4uxsCBAyGRSLBz5059xkdktCICOU+GiKil6bT8OigoCDt37kT//v0hlUrx7bffQiaT4bfffoOtra2+YyQySr0DXbD2YCr3kyEiakE611oKDw/Hjh078Nprr8HGxgZ//PEHkxiiW9wf4AypBEjLK0OWolzscIiITJLWPTJdu3aFRCKpd1wmk+HatWuIiopSH0tMTNRPdERGzMHKAp3aynHqigJxKXkY09Vb7JCIiEyO1okMSwIQNV1EoEtdInM5n4kMEVEL0DqRMaTdeomMRe9AF3z+dwpiOeGXiKhF6DxHhoju7v4AZ5hJJcjIL8PVQs6TISLSN50SmdraWnzwwQfo2bMnPDw84OzsrHEjojp2MnN0bisHwF1+iYhagk6JzJIlS/Dhhx/i4YcfhkKhwJw5czB27FhIpVIsXrxYzyESGbfe3E+GiKjF6JTIbNq0CWvXrsVLL70Ec3NzTJo0CV9++SUWLlyIuLg4fcdIZNRUBSQ5T4aISP90SmSys7PRuXNnAICdnR0UCgUAYPjw4fjtt9/0Fx2RCejh5wRzqQRXCsqRmV8mdjhERCZFp0TG29sbWVlZAOp2+d29ezcA4MiRI5DJZPqLjsgE2MrMEe59c54Me2WIiPSqSYlMYGAg8vLyMGbMGOzduxcA8MILL2DBggUICQnBlClTMH369BYJlMiY/TtPJl/kSIiITEuTai2lpaWhtrYW7777rvrYww8/DF9fX8TGxiIkJAQjRozQe5BExi4iyAWf7r+MuJQ8CILQ4C7ZRETUdDoVjbxdREQEIiIi9NEUkUnq7ucECzMJrhaWIzO/HL4uNmKHRERkEpqcyOzatQtyufyO14wcOVLngIhMkY2lOe7zdsTR9ALEpeQxkSEi0pMmJzJTp06943mJRILa2lqdAyIyVb0DXXA0vQCxKXmYeL+P2OEQEZmEJq9ays7OhlKpbPTGJIaoYar9ZFTzZIiIqPmalMhwgiKR7rr51s2TyVJUID2P+8kQEelDkxIZ/hVJpDtrSzN09XECwP1kiIj0pUmJzNSpU2Ftbd1SsRCZvN6BdUVVWa6AiEg/mpTIrFu3Dvb29i0VC5HJ6815MkREeqVTiQIi0k03XydYmkmRU1SJ1BulYodDRGT0mMgQtSIrCzN09XUEwHIFRET6wESGqJWp6i5xngwRUfM1K5G5dOkSdu3ahfLycgBc1USkDe4nQ0SkPzolMnl5eYiJiUFoaCiGDh2KrKwsAMCTTz6Jl156Sa8BEpmaLj6OsDSX4npxJS5f5zwZIqLm0CmRmT17NszNzZGRkQEbm39rxjz88MPYuXOn3oIjMkVWFmbo7sv9ZIiI9EGnRGb37t1477334O3trXE8JCQE6enpegmMyJSphpc4T4aIqHl0SmRKS0s1emJU8vPzIZPJmh0UkalTTfiN5zwZIqJm0SmR6dOnD9avX6/+WSKRQKlUYvny5ejfv7/egiMyVff5yGFlIcWNkipcyi0ROxwiIqNlrsudli9fjgEDBuDo0aOoqqrCK6+8grNnzyI/Px+HDx/Wd4xEJkdmbobufk44fCkPcSl5CHHnjtlERLrQqUemU6dOuHjxIqKjozFq1CiUlpZi7NixOH78OIKCgvQdI5FJiuB+MkREzaZTjwwAyOVyvP766/qMheieoponE5eSD0EQIJFIRI6IiMj46JzIVFRU4NSpU8jNzYVSqdQ4N3LkyGYHRmTqwr0dYW1hhvzSKlzMKUE7Dw4vERE1lU5DSzt37oSvry969+6NkSNHYvTo0erbmDFjtG5n8eLFkEgkGrewsDD1+YqKCsyYMQMuLi6ws7PDuHHjkJOTo0vIRAbH0lyKHv7cT4aIqDl0SmReeOEFTJgwAVlZWVAqlRq32traJrXVsWNHZGVlqW+HDh1Sn5s9eza2b9+OrVu34sCBA7h27RrGjh2rS8hEBkldd+kyExkiIl3oNLSUk5ODOXPmwN3dvfkBmJvDw8Oj3nGFQoH//e9/2Lx5Mx588EEAwLp169C+fXvExcWhd+/ezX5sIrGp95NJzYNSKUAq5TwZIqKm0KlHZvz48di/f79eAkhOToaXlxcCAwMxefJkZGRkAACOHTuG6upqxMTEqK8NCwuDr68vYmNjG22vsrISRUVFGjciQxXuLYeNpRkKyqpxIadY7HCIiIyOTj0yn3zyCSZMmICDBw+ic+fOsLCw0Dg/c+ZMrdrp1asXvv76a7Rr1w5ZWVlYsmQJ+vTpgzNnziA7OxuWlpZwdHTUuI+7uzuys7MbbXPZsmVYsmRJk58TkRgszKTo4e+Mvy9eR+zlPLT3dBA7JCIio6JTIvPtt99i9+7dsLKywv79+zWWjUokEq0TmSFDhqj/Pzw8HL169YKfnx++//57WFtb6xIa5s+fjzlz5qh/Lioqgo+Pj05tEbWGiEAX/H3xOuJS8jA9OkDscIiIjIpOiczrr7+OJUuWYN68eZBKdRqdapCjoyNCQ0Nx6dIlDBw4EFVVVSgsLNTolcnJyWlwTo2KTCZjvScyKr0DnQEA8an5nCdDRNREOmUhVVVVePjhh/WaxABASUkJLl++DE9PT3Tv3h0WFhbYu3ev+vyFCxeQkZGBiIgIvT4ukZg6t5XD1tIMivJqnMvmnC4ioqbQKROZOnUqtmzZ0uwHnzt3Lg4cOIC0tDT8888/GDNmDMzMzDBp0iTI5XI8+eSTmDNnDvbt24djx45h2rRpiIiI4IolMinmZlLcH1DXK8Nl2ERETaPT0FJtbS2WL1+OXbt2ITw8vN5k3w8//FCrdq5cuYJJkyYhLy8Prq6uiI6ORlxcHFxdXQEAH330EaRSKcaNG4fKykoMGjQIn376qS4hExm0iEAX7L9wHXEp+XiqT6DY4RARGQ2JIAhCU+/Uv3//xhuUSPDXX381Kyh9Kioqglwuh0KhgIMDV4SQYTqZWYhRqw/D3socJxY+BDPOkyGie5y239869cjs27dP58CIqL6OXg6wl5mjuKIG57KK0KmtXOyQiIiMgn5n6xKRTszNpOjJeTJERE2mdY/M2LFj8fXXX8PBweGu9Y5++umnZgdGdK/pHeiCvedzEZeSh6f7cp4MEZE2tE5k5HK5euM7uZzd3kT6FhFUV3cpITUfNbVKmJuxw5SI6G60TmTWrVuHN998E3PnzsW6detaMiaie1J7Twc4WJmjqKIGSVlFCPd2FDskIiKD16Q/+ZYsWYKSkpKWioXonmYmlaBnQF2vDOfJEBFpp0mJjA4rtYmoCVTlCuJSTCuRqVUKiL2ch20nriL2ch5qlfy3hIj0o8nLr28tEElE+qWaJ3MkrcBk5snsPJOFJduTkKWoUB/zlFth0YgOGNzJU8TIiMgUNDmRCQ0NvWsyk5+fr3NARPey9h4OkFtbQFFejTPXitDFx1HskJpl55ksPLcxEbf3v2QrKvDcxkSseawbkxkiapYmJzJLlizhqiWiFiKVStArwBm7k3IQeznPqBOZWqWAJduT6iUxACAAkABYsj0JAzt4cCdjItJZkxOZRx55BG5ubi0RCxGhbj+Z3Uk5iEvJw3MPBIkdjs4SUvM1hpNuJwDIUlQgITVfPaRGRNRUTRqA5/wYopb37zyZfFTXKkWORne5xY0nMbpcR0TUEK5aIjIw7dzt4WRjgbKqWpy+qhA7HJ252Vvp9ToiooY0KZFRKpUcViJqYXXzZIx/P5meAc5ws5c1el6CutVLqhpTRES6MP61nUQmyBT2k6lRKmFn1fg0PAHAohEdONGXiJqFiQyRAYoIagMAOJpWgKoa45snIwgCFv5yFinXS2FlIYWrnWW9a4Z28uDSayJqtiavWiKilhfiZgdnW0vkl1bh9NVCdPczruGXb/5Jw5ajmZBKgM8f74Ho4DZISM1HbnEFUq6X4uO9yYhPzUdFdS2sLMzEDpeIjBh7ZIgMkFQqUQ8vGds8mcOXbuCt384BAOYPaY9+oa4wk0oQEeSCUV3a4oUHg+Elt0JeaRV+PXlN5GiJyNgxkSEyUL0Db074NaJ5Mul5pfjPpkTUKgWM7doWT/UJqHeNuZkUUyP9AQBfHUrlakgiahYmMkQGKuJmInMsvQCVNbUiR3N3JZU1eHr9USjKq3GfjyOWju3c6N5Tj9zvC2sLM5zPLjaqRI2IDA8TGSIDFexmhzZ2lqioVuJkpmHvJ6NUCpi95QQu5pTAzV6GLx7vfse5L3IbC4zv7g0A+OpQWitFSUSmiIkMkYGSSCTodbNXxtCXYX/050XsScqBpbkUX0zpAXeHu29y90SUPwBg7/kcpN0obeEIichUMZEhMmCq4SVDnvC749Q1rPrrEgDg3bGdtS50GeRqh/7tXCEIwNf/pLVcgERk0pjIEBkw1YTfxIwCVFQb3jyZM1cVmLv1JADg6T4BGNvNu0n3nx5dNxl469FMFFVU6z0+IjJ9TGSIDFiQqy1c7WWorFHiRGah2OFouFFSiWfWH0VFtRJ9Q10xb0j7JrcRHdwGIW52KK2qxfdHMlsgSiIydUxkiAyYRCJR98oY0jyZqholntt4DNcUFQhsY4tVk7rqVGpAIpGoe2W+/icNtUouxSaipmEiQ2TgDG2ejCAIWPTrGRxJK4C9zBxrp/aA3NpC5/bGdG0LJxsLXCkox56kHD1GSkT3AiYyRAZOtcPv8cxCg5gnsyEuHd8mZEIiAVZO6oogV7tmtWdlYYZJPX0BAOsOp+ojRCK6hzCRITJwAW1s4e4gQ1WNEokZBaLG8s/lG1iyPQkA8OrgMPQPc9NLu49H+MFcKkF8aj7OXDXsPXOIyLAwkSEycJrzZPJFiyMzvwwzbpYfGN3FC8/2DdRb255yawztXFcJe93hNL21S0Smj4kMkRFQzZOJE2meTOnN8gMFZdUI95bj3XHhjZYf0JVq0u/2k9eQW1yh17aJyHQxkSEyAqoemROZhSivat15MkqlgDnfn8D57GK42svwxeM97lh+QFddfBzRzdcRVbVKbIrL0Hv7RGSamMgQGQE/Fxt4yq1QVdv682RW7E3GrrM5sDST4vPHu8NDfvfyA7pS9cpsik83iInNRGT4mMgQGQGx9pP543QWVu5NBgC8M6YTuvk6tejjDe7oAS+5FW6UVGH7yWst+lhEZBqYyBAZidbeTybpWhHmfF9XfmB6VAAm9PBp8cc0N5NiSqQ/AOCrw2kQBG6QR0R3xkSGyEioemROXilEWVVNiz5WXkklnl5/FOXVtegT0gavDQ1r0ce71SP3+8DawgznsopEXaVFRMaBiQyRkfBxtkZbR2tU1wo4lt5y82SqapR4blMirhaWw9/FBqsmdYW5Wev9U+FoY4lx3dsCAL7iBnlEdBdMZIiMhEQiQa+bu/y25DyZJdvPIiE1H3Yyc3w5tQccbSxb7LEa80Rk3aTfP8/lID2vtNUfn4iMBxMZIiPS0vNkNsalY1N8BiQS4ONHuiDYzb5FHudugt3s0C/UFYIAfPNPuigxEJFxMJhE5t1334VEIsGsWbPUxyoqKjBjxgy4uLjAzs4O48aNQ04Oi8rRvUs1T+bUFQVKK/U7TyYuJQ+Lfz0LAJj7UDsMaO+u1/abSrUU+/ujmSiuqBY1FiIyXAaRyBw5cgSff/45wsPDNY7Pnj0b27dvx9atW3HgwAFcu3YNY8eOFSlKIvH5ONvA28kaNUoBR/U4TyYzvwz/2ZSIGqWAEfd54T8PBOmtbV31DWmDYDc7lFTWYOvRK2KHQ0QGSvREpqSkBJMnT8batWvh5PTvHhUKhQL/+9//8OGHH+LBBx9E9+7dsW7dOvzzzz+Ii4sTMWIicUXoeT8ZVfmB/NIqdGrrgOUtUH5AFxKJBNOi/AEAX/+Thloll2ITUX2iJzIzZszAsGHDEBMTo3H82LFjqK6u1jgeFhYGX19fxMbGtnaYRAajtx7nySiVAuZuPYnz2cVoY1dXfsDaUv/lB3Q1tqs35NYWyMgvw95zHFYmovpETWS+++47JCYmYtmyZfXOZWdnw9LSEo6OjhrH3d3dkZ2d3WiblZWVKCoq0rgRmZLeQXWJzOmrCpQ0c57Mqr8u4Y8z2bAwk+Czx7rBy9FaHyHqjbWlGR7t5QuAS7GJqGGiJTKZmZl48cUXsWnTJlhZ6a92y7JlyyCXy9U3H5+W342UqDW1dbSGr7MNapUCjqTpvmHczjPZ+OjPiwCAt0d3Qg9/Z32FqFdTIvxgJpUgLiUfZ68pxA6HiAyMaInMsWPHkJubi27dusHc3Bzm5uY4cOAAVq5cCXNzc7i7u6OqqgqFhYUa98vJyYGHh0ej7c6fPx8KhUJ9y8zMbOFnQtT61PNkdBxeOp9dhDnfnwAAPBHpj4fv99VXaHrnKbfG0M6eAIB1h9PEDYaIDI5oicyAAQNw+vRpnDhxQn3r0aMHJk+erP5/CwsL7N27V32fCxcuICMjAxEREY22K5PJ4ODgoHEjMjW9g3TfGC+/tApPfXMUZVW1iAp2wRvD2us7PL2bfnPS768nruF6caW4wRCRQTEX64Ht7e3RqVMnjWO2trZwcXFRH3/yyScxZ84cODs7w8HBAS+88AIiIiLQu3dvMUImMhiqCb+nrypQVFENBysLre5XXavEfzYdw5WCcvg62+CTSd1atfyArrr6OqGrryOOZxRiU3w6ZsWEih0SERkIg/4X7KOPPsLw4cMxbtw49O3bFx4eHvjpp5/EDotIdJ5ya/i72EApAEebME/mrR1JiEvJh62lGb6c2gNOtq1ffkBX06LqNsjbGJeOyppakaMhIkMhWo9MQ/bv36/xs5WVFVavXo3Vq1eLExCRAYsIckFaXhliL+fhwbC778L7bUIG1sfWbff/0cNdEOouTvkBXQ3p5AEPBytkF1Vgx8ksjOvuLXZIRGQADLpHhoga11u9Md7de2QSUvOxcNsZAMBLA0PxUMfGJ8wbKgszKaZE+gGoW4otCNwgj0hMtUoBsZfzsO3EVcRezhNt00qD6pEhIu2pEpmz1xRQlFdDbt3wPJkrBWV4buMxVNcKGNbZE88/GNyaYerVpPt9sXJvMs5eK0JCaj563XwNiKh17TyThSXbk5ClqFAf85RbYdGIDhjcybNVY2GPDJGRcnewQmAbWygF4Ehqw70yZVU1eGb9MeSVVqGDpwPen2AY5Qd05WRribHd6oaUuEEekTh2nsnCcxsTNZIYAMhWVOC5jYnYeSarVeNhIkNkxFS7/MY2sAxbEAS8vPUUkrKK4GJribVTe8DG0vg7YadF+gMAdiflICOvTNxgiO4xtUoBS7YnoaFBJNWxJduTWnWYiYkMkRHrfYcCkqv3XcJvp7NgYSbBmse6o62BlR/QVYi7PfqGukIQgG9i08QOh+ieoFQKSM4pxvKd5+v1xNxKAJClqEBCI73ELcH4/zwjuof1DqzbGC8pqwiFZVVwtKlbTr37bDY+2F1XfmDJyE7oGWCY5Qd0NT3KH39fvI4tRzIxKyYE9lruo0NE2ikorcKJK4U4nl6A45mFOJFZiOIK7Wu75RY3nuzoGxMZIiPmZm+FwDY2SLlRhk/+uoQB7d0ht7bA7C0nANTVKVIVXTQlfUNcEeRqi8vXS/HDsSvqPWaIqOlqapU4n12M45mFOJ5RgBMZhUi5UVrvOmsLM/i72OBcdvFd23Sz118NxbthIkNkxHaeyUJ2Ud2W/V8eSsWXh1JhJpGgVhAQEeiCBcM7iBxhy5BKJZgWFYA3fjmDr/9Jw5QIf5hJjXcSM1Fryi2qQGJGIY5nFuB4RiFOX1GgvLr+JpOBrrbo6lO3q3ZXX0e0c7eHRCJB9Ht/IVtR0eA8GQkAD7lVq/YCM5EhMlKqlQO3/2NSe3N/lbHd2sLCCMoP6Gpst7Z4f9cFpOeV4a/zuRjY4e6bAhLdayqqa3H2WhGOZ9wcIsooxNXC8nrX2VuZ15UC8alLWrr4OKqHqm+3aEQHPLcxERJA498fyS3nW/MPCyYyREboTisHVD7ccxFju3mbbE+FjaU5Hunpg88PpOCrQ6lMZMik1CoFJKTmI7e4Am72dT0cd/tdFgQBVwrK1UNExzMKkXStCFW1So3rpBKgnYdDXU+LjyO6+johsI0tpFr+WzG4kyfWPNat3j4yHiLtI8NEhsgIJaTm33HlAPDvyoGIINPdNG5KhD++PJiK2JQ8nMsqQntPVrsn46ftZnOllTU4dUWhHiI6nlGIGyX1q8O3sbNEl1uGiMK9HWEna97X/+BOnhjYwaPJyVZLYCJDZIS0XRHQmisHxNDW0RqDO3ngt1NZWHc4FcvH3yd2SETN0tiQcbaiAv+3MRFTIvxQoxRwPKMQF7KLcPt2LRZmEnTwkquHiLr5OsHbybpFNsI0k0oM4g8lJjJERkjbFQGtuXJALNOjAvDbqSz8cuIaXhkchjZ2MrFDItKJNpvNqQq/qrR1tEaXW4aIOno5wMrCrMVjNSRMZIiMUM8AZ3jKrQxq5YBYuvk64j4fR5zMLMTm+AzMHBAidkhETVZdq8Tm+Iy7DhkDwIj7PDGssxe6+jrC3cH0/1i5G9Nd0kBkwsykEiwaUbe0+vYOY7FWDohFIpFgepQ/AGBDXDoqa+ovIyUyNEqlgDNXFVj7dwqmrUtAlyW7sejXs1rdN6a9OwZ38mAScxN7ZIiMlKGtHBDT0M6eWPr7OeQUVeK3U1nqwpJEhkIQBFzKLcE/l/Pwz+UbiEvJh6K8WuMaO5kZSirvnojfC0PGTcFEhsiIGdLKATFZmEkxJcIf7++6gP8dSsWYrm2Nuso3GT9BEJCZX45/Lt+4mbzk1VtRZC8zR69AZ0QEtUFkkAuCXe3Q9/19HDJuIiYyREbOUFYOiO3Rnr5YuTcZZ68V4UhaAf+xp1aXrahAbMoN/HOpLnG5feM5Kwsp7vd3RkSQCyKD2qCTlwPMb9u00tA2mzMGTGSIyCQ42VpibDdvfJuQga8OpTKRoRaXX1qFuJQ8da9LynXN+kQWZhJ09XG6mbi4oIuvI2Tmd15RxCHjpmMiQ0QmY1qUP75NyMDupGxk5pfBx9lG7JDIAOmyay4AFFdUIyE1Xz1UdC6rSOO8VAJ0bitXDxX18HeCjWXTv2Y5ZNw0TGSIyGSEutujT0gbHEy+gW/+ScMbJlo0k3Sn7a65AFBeVYtj6QXqHpfTVxWovW0HujAPe/VQUc8AZ8itLfQSJ4eMtcdEhohMyvSoABxMvoEtRzMxa2Bos7diJ9Nxp11zn9uYiJWTusJDbnVzjssNHM8orFenKKCNrXqoqHegCzdgNAD8DScik9Iv1BWBbWyRcqMUPx67gqmR/mKHRAZAm11zX/j2eL1znnIrdY9LZJALvBytWzROajomMkRkUqRSCaZF+WPBtrNYdzgVj/f207qqL5mufRdytdo118HKHH1CXRF5M3nxd7HhUn4Dx0SGiEzO2G7eeH/XBaTllWHfhVwMaO8udkjUSsqqanAptwQXsotxMacYF3JKcDG7GNlF2hVQfXNUJ4zu2raFoyR9YiJDRCbHVmaOST198fnfKfjqcCoTGRNUVaNEyo1bEpbsEiTnFiMjvwxCQ+NHWuK2/8aHiQwRmaQpkf748lAqDl/Kw/nsIoR5OIgd0j1B16XNd2ovPa8UF3OKcTGnBBdyinExuxipN0pRo2w4Y2ljZ4lQd3v1rZ2HHQJd7TD044PcNdcEMZEhIpPU1tEagzt64LfTWVh3KA3vjQ8XOyST15SlzbcTBAFXC8vVCcvF7GJcyCnGpdwSVNYoG7yPvZU52rnbI9TDHqFudnX/dbdvdCURd801TRJBaE4nnOErKiqCXC6HQqGAgwP/IiO6lxxLz8e4NbGwNJcidt6DcOFS2RbT2NJmVVqw5rFuGNzJE4Ig4HpJJZJzbp3HUozknBKUVNY02LaVhRSh7vYIcavrXanrZbGHh4NVkyfiNifZotal7fc3ExkiMlmCIGD06sM4eUWBlwaG4oUBIWKHZJJqlQKi3/vrjquCbCzN0MnLAcm5JSgoq27wGgszCQLb1PWstHP/N2HxdrLRa0+Jvoe/qGVo+/3NoSUiMlkSiQTTogIwa8sJrI9Lx7P9gmBpLr37HalJElLz77q0uayqFglpBQAAiQTwd7FFqLudemionbs9/NvYwsKs5d8f7pprWpjIEJFJG9rZE0t/P4fc4kr8dvoaxnT1Fjskk6FUCjh1VYFv/knT6vrHevvikft9EexmByuLOxdPJNIWExkiMmmW5lJMifDDB7svYt3hNIzu0pYbnDVDQWkV/k6+jv0XruPAxevIL63S+r7DOnuhU1t5C0ZH9yImMkRk8ib19MWqvy7h1BUFjqUXoIc/l9hqS6kUcPZaEfZdyMX+C7k4kVmIW1c928vMERXsgtiUfCjKG577wqXN1JKYyBCRyXOxk2FM17b47kgmvjqcykTmLhRl1bf0uuTiRolmr0uYhz0eaOeGB9q5orufEyzMpOpVSwCXNlPrYiJDRPeEaVEB+O5IJnaeycaVgjJ4O9mIHZLBEAQBSVlF2H/hOvZfyMWx9AKNXhdbSzNEBbdB/zA39At1bbBw4uBOnljzWLd6S5s9uLSZWhgTGSK6J7TzsEd0cBscunQD62PT8drQ9mKHJKqiimocTr5xc8joOnKLKzXOh7jZoX+YGx4IdUUPf2etVnsN7uSJgR08uLSZWhUTGSK6Z0yP9sehSzfwbUIGXhwQAlvZvfNPoCAIuJBTjH3n/+11uXWLf2sLM0QFu6iHjHTtseLSZmpt985vMRHd8x4IdUNAG1uk3ijFj4lXMCXCX+yQmqSpG7mVVNbgUPINHLhY1+ty+14vga626H8zcekZ4AyZOZdEk/FhIkNE9wypVIJpUf5YuO0s1h1Ow2O9/CA1kmEPbbbWFwQBl3JL1MNFR9LyUV37b6+LlYUUkUFt8EA7VzwQ6gZfF84TIuMnaiKzZs0arFmzBmlpaQCAjh07YuHChRgyZAgAoKKiAi+99BK+++47VFZWYtCgQfj000/h7u4uYtREZMzGdfPG+7suIPVGKfZfzMWDYYb/70ljdYyyFRV4bmMi/q9fEIoqqrH/wnVcLSzXuMbfxUY9XNQ70IUb0ZHJEbXW0vbt22FmZoaQkBAIgoBvvvkG77//Po4fP46OHTviueeew2+//Yavv/4acrkczz//PKRSKQ4fPqz1Y7DWEhHd7p3fkrD2YCqig9tg41O9xA7njrSpY3QrS3MpIgJd6npd2tUNpREZI6MtGuns7Iz3338f48ePh6urKzZv3ozx48cDAM6fP4/27dsjNjYWvXv31qo9JjJEdLvM/DL0e38flAKwe3ZfhLrbix1So2Iv52HS2ri7XvdQB3dM6umL3oEusLZkrwsZP22/vw2melptbS2+++47lJaWIiIiAseOHUN1dTViYmLU14SFhcHX1xexsbGNtlNZWYmioiKNGxHRrXycbTCoowcAYN3hVJGjaVh6Xim++ScNb+44q9X1w8I90T/MjUkM3XNEn+x7+vRpREREoKKiAnZ2dvj555/RoUMHnDhxApaWlnB0dNS43t3dHdnZ2Y22t2zZMixZsqSFoyYiYzc9OgB/nMnGT4lX8fKgMDjbWooaT2VNLRJS89XLo1NulDbp/m72Vi0UGZFhEz2RadeuHU6cOAGFQoEffvgBU6dOxYEDB3Rub/78+ZgzZ47656KiIvj4+OgjVCIyIT38nNC5rRynryrwbUIGZvQPbvUYrhSUqXfTPXwpD+XVtepz5lIJ7vd3Rt/QNvjfoVTklVTVm+wLsI4RkeiJjKWlJYKD6/4B6d69O44cOYKPP/4YDz/8MKqqqlBYWKjRK5OTkwMPD49G25PJZJDJZC0dNhEZOYlEgunR/pi95STWx6bh6T6BWu1e2xxVNUocTc/HgQvXse9CLi7mlGicd7OXoX87N/QPc0VUcBvYW1kAAALa2OK5jYmQgHWMiG4neiJzO6VSicrKSnTv3h0WFhbYu3cvxo0bBwC4cOECMjIyEBERIXKURGQKhnX2wtLfzyOnqBJ/nMnCqC5t9f4Y2YoKHLiYi33nr+PQpRsoqaxRn5NKgO5+TnignRv6t3NDe097SCT1ExLWMSJqnKiJzPz58zFkyBD4+vqiuLgYmzdvxv79+7Fr1y7I5XI8+eSTmDNnDpydneHg4IAXXngBERERWq9YIiK6E0tzKab09sN/91zE/w6lYuR9Xg0mEk1RU6vE8cxC7Dufi30XruNcluaCgzZ2lugXWrevS98QV8htLLRql3WMiBomaiKTm5uLKVOmICsrC3K5HOHh4di1axcGDhwIAPjoo48glUoxbtw4jQ3xiIj05dFevli17xJOXVEgMaMA3f2aPtfkenElDlysGy46ePE6iir+7XWRSID7vB3VQ0advOQ67ybMOkZE9RncPjL6xn1kiOhuXv3hFLYczUTvAGdM6uV7196OWqWAk1cK1RN1T11RaJx3tLFAv1BX9G/nhj4hbeBix3l7RE2l7fe3wc2RISJqbSEedgCAuNR8xKXmA6hfx6igtAp/J1/HvvO5OHDxOgrKqjXa6NxWjv7tXNGvnRu6+DhyyIeolTCRIaJ72s4zWXhnx7l6x7MVFfi/jYkYEe6JK4XlOJFZiFv7r+2tzNE3xBUPtHNFv3au3MeFSCRMZIjonlWrFLBke1KD+7Oojm0/laU+FuZhj/5hdSuMuvk6wtzMYDZHJ7pnMZEhontWQmq+VsUYn+4TgOnRAfCUW7dCVETUFPxzgojuWbnF2lWU7tRWziSGyEAxkSGie5a281o4/4XIcDGRIaJ7Vs8AZ3jKrdDY+iIJ6lYvsY4RkeFiIkNE9ywzqQSLRnQAgHrJDOsYERkHJjJEdE9T1THykGsOH3nIrbDmsW6sY0Rk4LhqiYjueaxjRGS8mMgQEYF1jIiMFYeWiIiIyGgxkSEiIiKjxUSGiIiIjBYTGSIiIjJaTGSIiIjIaDGRISIiIqPFRIaIiIiMFhMZIiIiMlpMZIiIiMhomfzOvoIgAACKiopEjoSIiIi0pfreVn2PN8bkE5ni4mIAgI+Pj8iREBERUVMVFxdDLpc3el4i3C3VMXJKpRLXrl2Dvb09JJJ7qwBcUVERfHx8kJmZCQcHB7HDMVp8HfWDr6N+8HXUD76O+tGSr6MgCCguLoaXlxek0sZnwph8j4xUKoW3t7fYYYjKwcGBv6h6wNdRP/g66gdfR/3g66gfLfU63qknRoWTfYmIiMhoMZEhIiIio8VExoTJZDIsWrQIMplM7FCMGl9H/eDrqB98HfWDr6N+GMLraPKTfYmIiMh0sUeGiIiIjBYTGSIiIjJaTGSIiIjIaDGRISIiIqPFRMYELVu2DPfffz/s7e3h5uaG0aNH48KFC2KHZfTeffddSCQSzJo1S+xQjM7Vq1fx2GOPwcXFBdbW1ujcuTOOHj0qdlhGpba2FgsWLEBAQACsra0RFBSEt9566651aO51f//9N0aMGAEvLy9IJBL88ssvGucFQcDChQvh6ekJa2trxMTEIDk5WZxgDdidXsfq6mq8+uqr6Ny5M2xtbeHl5YUpU6bg2rVrrRIbExkTdODAAcyYMQNxcXHYs2cPqqur8dBDD6G0tFTs0IzWkSNH8PnnnyM8PFzsUIxOQUEBoqKiYGFhgT/++ANJSUn473//CycnJ7FDMyrvvfce1qxZg08++QTnzp3De++9h+XLl2PVqlVih2bQSktLcd9992H16tUNnl++fDlWrlyJzz77DPHx8bC1tcWgQYNQUVHRypEatju9jmVlZUhMTMSCBQuQmJiIn376CRcuXMDIkSNbJziBTF5ubq4AQDhw4IDYoRil4uJiISQkRNizZ4/Qr18/4cUXXxQ7JKPy6quvCtHR0WKHYfSGDRsmTJ8+XePY2LFjhcmTJ4sUkfEBIPz888/qn5VKpeDh4SG8//776mOFhYWCTCYTvv32WxEiNA63v44NSUhIEAAI6enpLR4Pe2TuAQqFAgDg7OwsciTGacaMGRg2bBhiYmLEDsUo/frrr+jRowcmTJgANzc3dO3aFWvXrhU7LKMTGRmJvXv34uLFiwCAkydP4tChQxgyZIjIkRmv1NRUZGdna/xuy+Vy9OrVC7GxsSJGZvwUCgUkEgkcHR1b/LFMvmjkvU6pVGLWrFmIiopCp06dxA7H6Hz33XdITEzEkSNHxA7FaKWkpGDNmjWYM2cOXnvtNRw5cgQzZ86EpaUlpk6dKnZ4RmPevHkoKipCWFgYzMzMUFtbi3feeQeTJ08WOzSjlZ2dDQBwd3fXOO7u7q4+R01XUVGBV199FZMmTWqVgpxMZEzcjBkzcObMGRw6dEjsUIxOZmYmXnzxRezZswdWVlZih2O0lEolevTogaVLlwIAunbtijNnzuCzzz5jItME33//PTZt2oTNmzejY8eOOHHiBGbNmgUvLy++jmQwqqurMXHiRAiCgDVr1rTKY3JoyYQ9//zz2LFjB/bt2wdvb2+xwzE6x44dQ25uLrp16wZzc3OYm5vjwIEDWLlyJczNzVFbWyt2iEbB09MTHTp00DjWvn17ZGRkiBSRcXr55Zcxb948PPLII+jcuTMef/xxzJ49G8uWLRM7NKPl4eEBAMjJydE4npOToz5H2lMlMenp6dizZ0+r9MYATGRMkiAIeP755/Hzzz/jr7/+QkBAgNghGaUBAwbg9OnTOHHihPrWo0cPTJ48GSdOnICZmZnYIRqFqKioesv/L168CD8/P5EiMk5lZWWQSjX/yTYzM4NSqRQpIuMXEBAADw8P7N27V32sqKgI8fHxiIiIEDEy46NKYpKTk/Hnn3/CxcWl1R6bQ0smaMaMGdi8eTO2bdsGe3t79VivXC6HtbW1yNEZD3t7+3rzimxtbeHi4sL5Rk0we/ZsREZGYunSpZg4cSISEhLwxRdf4IsvvhA7NKMyYsQIvPPOO/D19UXHjh1x/PhxfPjhh5g+fbrYoRm0kpISXLp0Sf1zamoqTpw4AWdnZ/j6+mLWrFl4++23ERISgoCAACxYsABeXl4YPXq0eEEboDu9jp6enhg/fjwSExOxY8cO1NbWqr93nJ2dYWlp2bLBtfi6KGp1ABq8rVu3TuzQjB6XX+tm+/btQqdOnQSZTCaEhYUJX3zxhdghGZ2ioiLhxRdfFHx9fQUrKyshMDBQeP3114XKykqxQzNo+/bta/Dfw6lTpwqCULcEe8GCBYK7u7sgk8mEAQMGCBcuXBA3aAN0p9cxNTW10e+dffv2tXhsEkHgtpBERERknDhHhoiIiIwWExkiIiIyWkxkiIiIyGgxkSEiIiKjxUSGiIiIjBYTGSIiIjJaTGSIiIjIaDGRISKj4O/vjxUrVmh9/eLFi9GlS5cWi4eIDANLFBCRUThy5AhsbW3FDoOIDAwTGSIyCq6urmKHQEQGiENLRNRqHnjgAcycOROvvPIKnJ2d4eHhgcWLF2t139uHljIyMjBq1CjY2dnBwcEBEydORE5OTr37ff755/Dx8YGNjQ0mTpwIhUKhPrd//3707NkTtra2cHR0RFRUFNLT05v7NImoFTGRIaJW9c0338DW1hbx8fFYvnw53nzzTezZs6dJbSiVSowaNQr5+fk4cOAA9uzZg5SUFDz88MMa1126dAnff/89tm/fjp07d+L48eP4z3/+AwCoqanB6NGj0a9fP5w6dQqxsbF45plnIJFI9PZciajlcWiJiFpVeHg4Fi1aBAAICQnBJ598gr1792LgwIFat7F3716cPn0aqamp8PHxAQCsX78eHTt2xJEjR3D//fcDACoqKrB+/Xq0bdsWALBq1SoMGzYM//3vf2FpaQmFQoHhw4cjKCgIANC+fXt9PlUiagXskSGiVhUeHq7xs6enJ3Jzc5vUxrlz5+Dj46NOYgCgQ4cOcHR0xLlz59THfH191UkMAERERECpVOLChQtwdnbGE088gUGDBmHEiBH4+OOPkZWVpeOzIiKxMJEholZlYWGh8bNEIoFSqRQllnXr1iE2NhaRkZHYsmULQkNDERcXJ0osRKQbJjJEZHTat2+PzMxMZGZmqo8lJSWhsLAQHTp0UB/LyMjAtWvX1D/HxcVBKpWiXbt26mNdu3bF/Pnz8c8//6BTp07YvHlz6zwJItILJjJEZHRiYmLQuXNnTJ48GYmJiUhISMCUKVPQr18/9OjRQ32dlZUVpk6dipMnT+LgwYOYOXMmJk6cCA8PD6SmpmL+/PmIjY1Feno6du/ejeTkZM6TITIynOxLREZHIpFg27ZteOGFF9C3b19IpVIMHjwYq1at0rguODgYY8eOxdChQ5Gfn4/hw4fj008/BQDY2Njg/Pnz+Oabb5CXlwdPT0/MmDEDzz77rBhPiYh0JBEEQRA7CCKiu/H09MRbb72Fp556SuxQiMiAsEeGiAxaWVkZDh8+jJycHHTs2FHscIjIwDCRISLRbdq0qdEhHUEQYGVlhVmzZiEiIqKVIyMiQ8ehJSISXXFxcYPlBYC65dp+fn6tHBERGQsmMkRERGS0uPyaiIiIjBYTGSIiIjJaTGSIiIjIaDGRISIiIqPFRIaIiIiMFhMZIiIiMlpMZIiIiMhoMZEhIiIio/X/5o1nDJSjFMMAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plotting the results\n",
+    "plt.plot(n_jobs_values, performance_times_avg,marker='o')\n",
+    "plt.xlabel('n_jobs')\n",
+    "plt.ylabel('Time Taken (seconds)')\n",
+    "plt.title('MGWR Performance with Different n_jobs Values')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "pool.close() # Close the pool when you finish\n",
-    "pool.join()"
-   ]
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -228,7 +2092,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR replaces the repvious `multiprocessing.pool` based parallelization to `joblib` based. Users only need to specify the `n_jobs` parameter instead of passing a `pool`. 

Example use:
GWR
```
n_jobs = 8
bw = Sel_BW(coords, y, X, n_jobs= n_jobs).search()
GWR(coords, y, X, bw, n_jobs=n_jobs)
```
MGWR
```
n_jobs = -1 #use all
mgwr_selector = Sel_BW(coords, y, X, multi=True, n_jobs=n_jobs)
mgwr_bw = mgwr_selector.search()
mgwr_results = MGWR(coords, y, X, selector=mgwr_selector, n_jobs=n_jobs).fit()
```

The test sets are updated to reflect the new interface. The notebook example is also updated and the effectiveness can be compared here: [joblib-based (new)](https://github.com/Ziqi-Li/mgwr/blob/joblib/notebooks/GWR_MGWR_Parallel_Example.ipynb) vs. [mp-based (old)](https://github.com/pysal/mgwr/blob/master/notebooks/GWR_MGWR_Parallel_Example.ipynb)