### PR TITLE
Drop Python 3.10 support (#1373)

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -16,7 +16,7 @@
      strategy:
        matrix:
          os: ['ubuntu-latest']
-         environment-file: [.ci/39.yaml, .ci/310.yaml, .ci/311.yaml, .ci/311-DEV.yaml]
+         environment-file: [.ci/39.yaml, .ci/311.yaml, .ci/311-DEV.yaml]
          include:
            - environment-file: .ci/311.yaml
              os: macos-latest

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ def setup_package():
         url='https://github.com/pysal/mgwr',  #github repo
         maintainer='Taylor M. Oshan',
         maintainer_email='tayoshan@gmail.com',
-        python_requires='>3.5',
+        python_requires='>=3.11',
         test_suite='nose.collector',
         tests_require=['nose'],
         keywords='spatial statistics',


### PR DESCRIPTION
- Remove .ci/310.yaml from CI test matrix

- Update python_requires from >3.5 to >=3.11

- Addresses pysal/pysal#1373