### PR TITLE
drop 3.11 support - spec000

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -29,13 +29,22 @@ jobs:
           - ci/312-latest.yaml
           - ci/313-latest.yaml
           - ci/314-latest.yaml
+          - ci/314-numba-latest.yaml
           - ci/314-dev.yaml
         include:
+          # without numba
           - environment-file: ci/314-latest.yaml
             os: macos-15-intel
           - environment-file: ci/314-latest.yaml
             os: macos-latest
           - environment-file: ci/314-latest.yaml
+            os: windows-latest
+          # with numba
+          - environment-file: ci/314-numba-latest.yaml
+            os: macos-15-intel
+          - environment-file: ci/314-numba-latest.yaml
+            os: macos-latest
+          - environment-file: ci/314-numba-latest.yaml
             os: windows-latest
     defaults:
       run:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,4 +1,5 @@
-name: Tests
+---
+name: Continuous Integration
 
 on:
   push:
@@ -24,8 +25,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         environment-file:
-          - ci/311-oldest.yaml
-          - ci/311-latest.yaml
+          - ci/312-oldest.yaml
           - ci/312-latest.yaml
           - ci/313-latest.yaml
           - ci/314-latest.yaml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup micromamba
-        uses: mamba-org/setup-micromamba@v2
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-file: ${{ matrix.environment-file }}
           micromamba-version: "latest"
@@ -59,7 +59,14 @@ jobs:
 
       - name: Test mgwr
         run: |
-          pytest -v --color yes --cov mgwr --cov-append --cov-report term-missing --cov-report xml --timeout=300 mgwr
+          pytest mgwr \
+          -v \
+          --color yes \
+          --cov mgwr \
+          --cov-append \
+          --cov-report term-missing \
+          --cov-report xml \
+          --timeout=300
 
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **M**ultiscale **G**eographically **W**eighted **R**egression (MGWR)
 
-[![Build Status](https://travis-ci.org/pysal/mgwr.svg?branch=master)](https://travis-ci.org/pysal/mgwr)
+[![unittests](https://github.com/pysal/mgwr/actions/workflows/unittest.yml/badge.svg)](https://github.com/pysal/mgwr/actions/workflows/unittest.yml)
 [![Documentation Status](https://readthedocs.org/projects/mgwr/badge/?version=latest)](https://mgwr.readthedocs.io/en/latest/?badge=latest)
 [![PyPI version](https://badge.fury.io/py/mgwr.svg)](https://badge.fury.io/py/mgwr)
 

--- a/ci/312-latest.yaml
+++ b/ci/312-latest.yaml
@@ -3,11 +3,11 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
+  - libpysal
   - numpy
   - pandas
   - scikit-learn
   - scipy
-  - libpysal
   - spglm
   - spreg
   # testing

--- a/ci/312-oldest.yaml
+++ b/ci/312-oldest.yaml
@@ -1,13 +1,13 @@
-name: py311_mgwr-oldest
+name: test
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.12
+  - libpysal=4.12
   - numpy=2.0
   - pandas=2.3
   - scikit-learn=1.5
   - scipy=1.13
-  - libpysal=4.12
   - spglm=1.1.0
   - spreg=1.8
   # testing

--- a/ci/313-latest.yaml
+++ b/ci/313-latest.yaml
@@ -3,11 +3,11 @@ channels:
   - conda-forge
 dependencies:
   - python=3.13
+  - libpysal
   - numpy
   - pandas
   - scikit-learn
   - scipy
-  - libpysal
   - spglm
   - spreg
   # testing

--- a/ci/314-latest.yaml
+++ b/ci/314-latest.yaml
@@ -3,11 +3,11 @@ channels:
   - conda-forge
 dependencies:
   - python=3.14
+  - libpysal
   - numpy
   - pandas
   - scikit-learn
   - scipy
-  - libpysal
   - spglm
   - spreg
   # testing

--- a/ci/314-numba-latest.yaml
+++ b/ci/314-numba-latest.yaml
@@ -2,12 +2,13 @@ name: test
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.14
+  - libpysal
+  - numba
   - numpy
   - pandas
   - scikit-learn
   - scipy
-  - libpysal
   - spglm
   - spreg
   # testing

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -3,7 +3,7 @@
 Installation
 ============
 
-mgwr supports python `3.5`_ and `3.6`_ only. Please make sure that you are
+mgwr supports python >= `3.12`_. Please make sure that you are
 operating in a python 3 environment.
 
 Installing released version
@@ -36,11 +36,7 @@ your fork. By making changes
 to your local clone and submitting a pull request to `pysal/mgwr`_, you can
 contribute to the mgwr development.
 
-.. _3.5: https://docs.python.org/3.5/
-.. _3.6: https://docs.python.org/3.6/
+.. _3.12: https://docs.python.org/3.12/
 .. _Python Package Index: https://pypi.org/project/mgwr/
 .. _pysal/mgwr: https://github.com/pysal/mgwr
 .. _fork: https://help.github.com/articles/fork-a-repo/
-
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 dependencies = [
     "libpysal>=4.12",
     "numpy>=2.0",
@@ -37,9 +37,12 @@ dependencies = [
 
 [project.urls]
 Home = "https://github.com/pysal/mgwr/"
-Repository = "https://github.com/mgwr/spint"
+Repository = "https://github.com/pysal/mgwr"
 
 [project.optional-dependencies]
+plus = [
+    "numba",
+]
 dev_tests = [
     "pre-commit",
     "ruff",


### PR DESCRIPTION
This PR:

* drop 3.11 support (spec000)
  * https://github.com/pysal/pysal/issues/1375
* adds a `plus` optional dep for `numba`
  * see [here](https://github.com/pysal/mgwr/blob/2ae3f9c909be1b36de7bb53fef8159cb1e3586eb/mgwr/kernels.py#L9-L15) 
* adds a CI env with `numba`
* general deps clean up etc.